### PR TITLE
Using Kokkos::Experimental builtins in LAMMPS

### DIFF
--- a/src/KOKKOS/angle_charmm_kokkos.cpp
+++ b/src/KOKKOS/angle_charmm_kokkos.cpp
@@ -153,7 +153,7 @@ void AngleCharmmKokkos<DeviceType>::operator()(TagAngleCharmmCompute<NEWTON_BOND
   const F_FLOAT delz1 = x(i1,2) - x(i2,2);
 
   const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-  const F_FLOAT r1 = sqrt(rsq1);
+  const F_FLOAT r1 = Kokkos::Experimental::sqrt(rsq1);
 
   // 2nd bond
 
@@ -162,7 +162,7 @@ void AngleCharmmKokkos<DeviceType>::operator()(TagAngleCharmmCompute<NEWTON_BOND
   const F_FLOAT delz2 = x(i3,2) - x(i2,2);
 
   const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-  const F_FLOAT r2 = sqrt(rsq2);
+  const F_FLOAT r2 = Kokkos::Experimental::sqrt(rsq2);
 
   // Urey-Bradley bond
 
@@ -171,7 +171,7 @@ void AngleCharmmKokkos<DeviceType>::operator()(TagAngleCharmmCompute<NEWTON_BOND
   const F_FLOAT delzUB = x(i3,2) - x(i1,2);
 
   const F_FLOAT rsqUB = delxUB*delxUB + delyUB*delyUB + delzUB*delzUB;
-  const F_FLOAT rUB = sqrt(rsqUB);
+  const F_FLOAT rUB = Kokkos::Experimental::sqrt(rsqUB);
 
   // Urey-Bradley force & energy
 
@@ -192,13 +192,13 @@ void AngleCharmmKokkos<DeviceType>::operator()(TagAngleCharmmCompute<NEWTON_BOND
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;
 
-  F_FLOAT s = sqrt(1.0 - c*c);
+  F_FLOAT s = Kokkos::Experimental::sqrt(1.0 - c*c);
   if (s < SMALL) s = SMALL;
   s = 1.0/s;
 
   // harmonic force & energy
 
-  const F_FLOAT dtheta = acos(c) - d_theta0[type];
+  const F_FLOAT dtheta = Kokkos::Experimental::acos(c) - d_theta0[type];
   const F_FLOAT tk = d_k[type] * dtheta;
 
   if (eflag) eangle += tk*dtheta;

--- a/src/KOKKOS/angle_class2_kokkos.cpp
+++ b/src/KOKKOS/angle_class2_kokkos.cpp
@@ -174,7 +174,7 @@ void AngleClass2Kokkos<DeviceType>::operator()(TagAngleClass2Compute<NEWTON_BOND
   const F_FLOAT delz1 = x(i1,2) - x(i2,2);
 
   const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-  const F_FLOAT r1 = sqrt(rsq1);
+  const F_FLOAT r1 = Kokkos::Experimental::sqrt(rsq1);
 
   // 2nd bond
 
@@ -183,7 +183,7 @@ void AngleClass2Kokkos<DeviceType>::operator()(TagAngleClass2Compute<NEWTON_BOND
   const F_FLOAT delz2 = x(i3,2) - x(i2,2);
 
   const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-  const F_FLOAT r2 = sqrt(rsq2);
+  const F_FLOAT r2 = Kokkos::Experimental::sqrt(rsq2);
 
   // angle (cos and sin)
 
@@ -193,13 +193,13 @@ void AngleClass2Kokkos<DeviceType>::operator()(TagAngleClass2Compute<NEWTON_BOND
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;
 
-  F_FLOAT s = sqrt(1.0 - c*c);
+  F_FLOAT s = Kokkos::Experimental::sqrt(1.0 - c*c);
   if (s < SMALL) s = SMALL;
   s = 1.0/s;
 
   // force & energy for angle term
 
-  const F_FLOAT dtheta = acos(c) - d_theta0[type];
+  const F_FLOAT dtheta = Kokkos::Experimental::acos(c) - d_theta0[type];
   const F_FLOAT dtheta2 = dtheta*dtheta;
   const F_FLOAT dtheta3 = dtheta2*dtheta;
   const F_FLOAT dtheta4 = dtheta3*dtheta;

--- a/src/KOKKOS/angle_cosine_kokkos.cpp
+++ b/src/KOKKOS/angle_cosine_kokkos.cpp
@@ -157,7 +157,7 @@ void AngleCosineKokkos<DeviceType>::operator()(TagAngleCosineCompute<NEWTON_BOND
   const F_FLOAT delz1 = x(i1,2) - x(i2,2);
 
   const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-  const F_FLOAT r1 = sqrt(rsq1);
+  const F_FLOAT r1 = Kokkos::Experimental::sqrt(rsq1);
 
   // 2nd bond
 
@@ -166,7 +166,7 @@ void AngleCosineKokkos<DeviceType>::operator()(TagAngleCosineCompute<NEWTON_BOND
   const F_FLOAT delz2 = x(i3,2) - x(i2,2);
 
   const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-  const F_FLOAT r2 = sqrt(rsq2);
+  const F_FLOAT r2 = Kokkos::Experimental::sqrt(rsq2);
 
   // c = cosine of angle
 

--- a/src/KOKKOS/angle_harmonic_kokkos.cpp
+++ b/src/KOKKOS/angle_harmonic_kokkos.cpp
@@ -158,7 +158,7 @@ void AngleHarmonicKokkos<DeviceType>::operator()(TagAngleHarmonicCompute<NEWTON_
   const F_FLOAT delz1 = x(i1,2) - x(i2,2);
 
   const F_FLOAT rsq1 = delx1*delx1 + dely1*dely1 + delz1*delz1;
-  const F_FLOAT r1 = sqrt(rsq1);
+  const F_FLOAT r1 = Kokkos::Experimental::sqrt(rsq1);
 
   // 2nd bond
 
@@ -167,7 +167,7 @@ void AngleHarmonicKokkos<DeviceType>::operator()(TagAngleHarmonicCompute<NEWTON_
   const F_FLOAT delz2 = x(i3,2) - x(i2,2);
 
   const F_FLOAT rsq2 = delx2*delx2 + dely2*dely2 + delz2*delz2;
-  const F_FLOAT r2 = sqrt(rsq2);
+  const F_FLOAT r2 = Kokkos::Experimental::sqrt(rsq2);
 
   // angle (cos and sin)
 
@@ -177,13 +177,13 @@ void AngleHarmonicKokkos<DeviceType>::operator()(TagAngleHarmonicCompute<NEWTON_
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;
 
-  F_FLOAT s = sqrt(1.0 - c*c);
+  F_FLOAT s = Kokkos::Experimental::sqrt(1.0 - c*c);
   if (s < SMALL) s = SMALL;
   s = 1.0/s;
 
   // force & energy
 
-  const F_FLOAT dtheta = acos(c) - d_theta0[type];
+  const F_FLOAT dtheta = Kokkos::Experimental::acos(c) - d_theta0[type];
   const F_FLOAT tk = d_k[type] * dtheta;
 
   F_FLOAT eangle = 0.0;

--- a/src/KOKKOS/atom_vec_spin_kokkos.cpp
+++ b/src/KOKKOS/atom_vec_spin_kokkos.cpp
@@ -1070,7 +1070,7 @@ void AtomVecSpinKokkos::data_atom(double *coord, imageint imagetmp,
   h_sp(nlocal,0) = utils::numeric(FLERR,values[6],true,lmp);
   h_sp(nlocal,1) = utils::numeric(FLERR,values[7],true,lmp);
   h_sp(nlocal,2) = utils::numeric(FLERR,values[8],true,lmp);
-  double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
+  double inorm = 1.0/Kokkos::Experimental::sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);
   h_sp(nlocal,0) *= inorm;
@@ -1104,7 +1104,7 @@ int AtomVecSpinKokkos::data_atom_hybrid(int nlocal, char **values)
   h_sp(nlocal,0) = utils::numeric(FLERR,values[1],true,lmp);
   h_sp(nlocal,1) = utils::numeric(FLERR,values[2],true,lmp);
   h_sp(nlocal,2) = utils::numeric(FLERR,values[3],true,lmp);
-  double inorm = 1.0/sqrt(sp[nlocal][0]*sp[nlocal][0] +
+  double inorm = 1.0/Kokkos::Experimental::sqrt(sp[nlocal][0]*sp[nlocal][0] +
                           sp[nlocal][1]*sp[nlocal][1] +
                           sp[nlocal][2]*sp[nlocal][2]);
   sp[nlocal][0] *= inorm;

--- a/src/KOKKOS/bond_class2_kokkos.cpp
+++ b/src/KOKKOS/bond_class2_kokkos.cpp
@@ -149,7 +149,7 @@ void BondClass2Kokkos<DeviceType>::operator()(TagBondClass2Compute<NEWTON_BOND,E
   const F_FLOAT delz = x(i1,2) - x(i2,2);
 
   const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT dr = r - d_r0[type];
   const F_FLOAT dr2 = dr*dr;
   const F_FLOAT dr3 = dr2*dr;

--- a/src/KOKKOS/bond_harmonic_kokkos.cpp
+++ b/src/KOKKOS/bond_harmonic_kokkos.cpp
@@ -147,7 +147,7 @@ void BondHarmonicKokkos<DeviceType>::operator()(TagBondHarmonicCompute<NEWTON_BO
   const F_FLOAT delz = x(i1,2) - x(i2,2);
 
   const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT dr = r - d_r0[type];
   const F_FLOAT rk = d_k[type] * dr;
 

--- a/src/KOKKOS/compute_orientorder_atom_kokkos.cpp
+++ b/src/KOKKOS/compute_orientorder_atom_kokkos.cpp
@@ -439,14 +439,14 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::calc_boop1(int /*ncount*/, int ii
   const double r0 = d_rlist(ii,ineigh,0);
   const double r1 = d_rlist(ii,ineigh,1);
   const double r2 = d_rlist(ii,ineigh,2);
-  const double rmag = sqrt(r0*r0 + r1*r1 + r2*r2);
+  const double rmag = Kokkos::Experimental::sqrt(r0*r0 + r1*r1 + r2*r2);
   if (rmag <= MY_EPSILON) {
     return;
   }
 
   const double costheta = r2 / rmag;
   SNAcomplex expphi = {r0,r1};
-  const double rxymag = sqrt(expphi.re*expphi.re+expphi.im*expphi.im);
+  const double rxymag = Kokkos::Experimental::sqrt(expphi.re*expphi.re+expphi.im*expphi.im);
   if (rxymag <= MY_EPSILON) {
     expphi.re = 1.0;
     expphi.im = 0.0;
@@ -521,11 +521,11 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::calc_boop2(int ncount, int ii) co
   int jj = 0;
   for (int il = 0; il < nqlist; il++) {
     int l = d_qlist[il];
-    double qnormfac = sqrt(MY_4PI/(2*l+1));
+    double qnormfac = Kokkos::Experimental::sqrt(MY_4PI/(2*l+1));
     double qm_sum = 0.0;
     for (int m = 0; m < 2*l+1; m++)
       qm_sum += d_qnm(ii,il,m).re*d_qnm(ii,il,m).re + d_qnm(ii,il,m).im*d_qnm(ii,il,m).im;
-    d_qnarray(i,jj++) = qnormfac * sqrt(qm_sum);
+    d_qnarray(i,jj++) = qnormfac * Kokkos::Experimental::sqrt(qm_sum);
   }
 
   // calculate W_l
@@ -545,7 +545,7 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::calc_boop2(int ncount, int ii) co
           idxcg_count++;
         }
       }
-      d_qnarray(i,jj++) = wlsum/sqrt(2.0*l+1.0);
+      d_qnarray(i,jj++) = wlsum/Kokkos::Experimental::sqrt(2.0*l+1.0);
     }
   }
 
@@ -569,9 +569,9 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::calc_boop2(int ncount, int ii) co
       if (d_qnarray(i,il) < QEPSILON)
         d_qnarray(i,jj++) = 0.0;
       else {
-        const double qnormfac = sqrt(MY_4PI/(2*l+1));
+        const double qnormfac = Kokkos::Experimental::sqrt(MY_4PI/(2*l+1));
         const double qnfac = qnormfac/d_qnarray(i,il);
-        d_qnarray(i,jj++) = wlsum/sqrt(2.0*l+1.0)*(qnfac*qnfac*qnfac);
+        d_qnarray(i,jj++) = wlsum/Kokkos::Experimental::sqrt(2.0*l+1.0)*(qnfac*qnfac*qnfac);
       }
     }
   }
@@ -587,7 +587,7 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::calc_boop2(int ncount, int ii) co
         d_qnarray(i,jj++) = 0.0;
       }
     else {
-      const double qnormfac = sqrt(MY_4PI/(2*l+1));
+      const double qnormfac = Kokkos::Experimental::sqrt(MY_4PI/(2*l+1));
       const double qnfac = qnormfac/d_qnarray(i,il);
       for (int m = 0; m < 2*l+1; m++) {
         d_qnarray(i,jj++) = d_qnm(ii,il,m).re * qnfac;
@@ -600,20 +600,20 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::calc_boop2(int ncount, int ii) co
 
 /* ----------------------------------------------------------------------
    polar prefactor for spherical harmonic Y_l^m, where
-   Y_l^m (theta, phi) = prefactor(l, m, cos(theta)) * exp(i*m*phi)
+   Y_l^m (theta, phi) = prefactor(l, m, Kokkos::Experimental::cos(theta)) * Kokkos::Experimental::exp(i*m*phi)
 ------------------------------------------------------------------------- */
 
 template<class DeviceType>
 KOKKOS_INLINE_FUNCTION
 double ComputeOrientOrderAtomKokkos<DeviceType>::polar_prefactor(int l, int m, double costheta) const
 {
-  const int mabs = abs(m);
+  const int mabs = Kokkos::Experimental::abs(m);
 
   double prefactor = 1.0;
   for (int i=l-mabs+1; i < l+mabs+1; ++i)
     prefactor *= static_cast<double>(i);
 
-  prefactor = sqrt(static_cast<double>(2*l+1)/(MY_4PI*prefactor))
+  prefactor = Kokkos::Experimental::sqrt(static_cast<double>(2*l+1)/(MY_4PI*prefactor))
     * associated_legendre(l,mabs,costheta);
 
   if ((m < 0) && (m % 2)) prefactor = -prefactor;
@@ -623,7 +623,7 @@ double ComputeOrientOrderAtomKokkos<DeviceType>::polar_prefactor(int l, int m, d
 
 /* ----------------------------------------------------------------------
    associated legendre polynomial
-   sign convention: P(l,l) = (2l-1)!!(-sqrt(1-x^2))^l
+   sign convention: P(l,l) = (2l-1)!!(-Kokkos::Experimental::sqrt(1-x^2))^l
 ------------------------------------------------------------------------- */
 
 template<class DeviceType>
@@ -635,7 +635,7 @@ double ComputeOrientOrderAtomKokkos<DeviceType>::associated_legendre(int l, int 
   double p(1.0), pm1(0.0), pm2(0.0);
 
   if (m != 0) {
-    const double msqx = -sqrt(1.0-x*x);
+    const double msqx = -Kokkos::Experimental::sqrt(1.0-x*x);
     for (int i=1; i < m+1; ++i)
       p *= static_cast<double>(2*i-1) * msqx;
   }
@@ -697,7 +697,7 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::init_clebsch_gordan()
           }
 
           cc2 = m - l;
-          sfaccg = sqrt(factorial(l + aa2) *
+          sfaccg = Kokkos::Experimental::sqrt(factorial(l + aa2) *
                         factorial(l - aa2) *
                         factorial(l + bb2) *
                         factorial(l - bb2) *
@@ -707,7 +707,7 @@ void ComputeOrientOrderAtomKokkos<DeviceType>::init_clebsch_gordan()
 
           sfac1 = factorial(3*l + 1);
           sfac2 = factorial(l);
-          dcg = sqrt(sfac2*sfac2*sfac2 / sfac1);
+          dcg = Kokkos::Experimental::sqrt(sfac2*sfac2*sfac2 / sfac1);
 
           h_cglist[idxcg_count] = sum * dcg * sfaccg;
           idxcg_count++;

--- a/src/KOKKOS/dihedral_charmm_kokkos.cpp
+++ b/src/KOKKOS/dihedral_charmm_kokkos.cpp
@@ -247,14 +247,14 @@ void DihedralCharmmKokkos<DeviceType>::operator()(TagDihedralCharmmCompute<NEWTO
   const F_FLOAT rasq = ax*ax + ay*ay + az*az;
   const F_FLOAT rbsq = bx*bx + by*by + bz*bz;
   const F_FLOAT rgsq = vb2xm*vb2xm + vb2ym*vb2ym + vb2zm*vb2zm;
-  const F_FLOAT rg = sqrt(rgsq);
+  const F_FLOAT rg = Kokkos::Experimental::sqrt(rgsq);
 
   F_FLOAT rginv,ra2inv,rb2inv;
   rginv = ra2inv = rb2inv = 0.0;
   if (rg > 0) rginv = 1.0/rg;
   if (rasq > 0) ra2inv = 1.0/rasq;
   if (rbsq > 0) rb2inv = 1.0/rbsq;
-  const F_FLOAT rabinv = sqrt(ra2inv*rb2inv);
+  const F_FLOAT rabinv = Kokkos::Experimental::sqrt(ra2inv*rb2inv);
 
   F_FLOAT c = (ax*bx + ay*by + az*bz)*rabinv;
   F_FLOAT s = rg*rabinv*(ax*vb3x + ay*vb3y + az*vb3z);
@@ -377,7 +377,7 @@ void DihedralCharmmKokkos<DeviceType>::operator()(TagDihedralCharmmCompute<NEWTO
 
     F_FLOAT forcecoul;
     if (implicit) forcecoul = qqrd2e * q[i1]*q[i4]*r2inv;
-    else forcecoul = qqrd2e * q[i1]*q[i4]*sqrt(r2inv);
+    else forcecoul = qqrd2e * q[i1]*q[i4]*Kokkos::Experimental::sqrt(r2inv);
     const F_FLOAT forcelj = r6inv * (d_lj14_1(itype,jtype)*r6inv - d_lj14_2(itype,jtype));
     const F_FLOAT fpair = d_weight[type] * (forcelj+forcecoul)*r2inv;
 

--- a/src/KOKKOS/dihedral_class2_kokkos.cpp
+++ b/src/KOKKOS/dihedral_class2_kokkos.cpp
@@ -232,11 +232,11 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // distance: c0 calculation
 
   const F_FLOAT r1mag2 = vb1x*vb1x + vb1y*vb1y + vb1z*vb1z;
-  const F_FLOAT r1 = sqrt(r1mag2);
+  const F_FLOAT r1 = Kokkos::Experimental::sqrt(r1mag2);
   const F_FLOAT r2mag2 = vb2x*vb2x + vb2y*vb2y + vb2z*vb2z;
-  const F_FLOAT r2 = sqrt(r2mag2);
+  const F_FLOAT r2 = Kokkos::Experimental::sqrt(r2mag2);
   const F_FLOAT r3mag2 = vb3x*vb3x + vb3y*vb3y + vb3z*vb3z;
-  const F_FLOAT r3 = sqrt(r3mag2);
+  const F_FLOAT r3 = Kokkos::Experimental::sqrt(r3mag2);
 
   const F_FLOAT sb1 = 1.0/r1mag2;
   const F_FLOAT rb1 = 1.0/r1;
@@ -263,12 +263,12 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // cos and sin of 2 angles and final c
 
   F_FLOAT sin2 = MAX(1.0 - costh12*costh12,0.0);
-  F_FLOAT sc1 = sqrt(sin2);
+  F_FLOAT sc1 = Kokkos::Experimental::sqrt(sin2);
   if (sc1 < SMALL) sc1 = SMALL;
   sc1 = 1.0/sc1;
 
   sin2 = MAX(1.0 - costh23*costh23,0.0);
-  F_FLOAT sc2 = sqrt(sin2);
+  F_FLOAT sc2 = Kokkos::Experimental::sqrt(sin2);
   if (sc2 < SMALL) sc2 = SMALL;
   sc2 = 1.0/sc2;
 
@@ -285,9 +285,9 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;
   const F_FLOAT cosphi = c;
-  F_FLOAT phi = acos(c);
+  F_FLOAT phi = Kokkos::Experimental::acos(c);
 
-  F_FLOAT sinphi = sqrt(1.0 - c*c);
+  F_FLOAT sinphi = Kokkos::Experimental::sqrt(1.0 - c*c);
   sinphi = MAX(sinphi,SMALL);
 
   // n123 = vb1 x vb2
@@ -318,7 +318,7 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   const F_FLOAT sz2  = a12*vb1z + a22*vb2z + a23*vb3z;
   const F_FLOAT sz12 = a13*vb1z + a23*vb2z + a33*vb3z;
 
-  // set up d(cos(phi))/d(r) and dphi/dr arrays
+  // set up d(Kokkos::Experimental::cos(phi))/d(r) and dphi/dr arrays
 
   F_FLOAT dcosphidr[4][3], dphidr[4][3];
 
@@ -347,12 +347,12 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   const F_FLOAT dphi2 = 2.0*phi - d_phi2[type];
   const F_FLOAT dphi3 = 3.0*phi - d_phi3[type];
 
-  if (eflag) edihedral = d_k1[type]*(1.0 - cos(dphi1)) +
-                     d_k2[type]*(1.0 - cos(dphi2)) +
-                     d_k3[type]*(1.0 - cos(dphi3));
+  if (eflag) edihedral = d_k1[type]*(1.0 - Kokkos::Experimental::cos(dphi1)) +
+                     d_k2[type]*(1.0 - Kokkos::Experimental::cos(dphi2)) +
+                     d_k3[type]*(1.0 - Kokkos::Experimental::cos(dphi3));
 
-  const F_FLOAT de_dihedral = d_k1[type]*sin(dphi1) + 2.0*d_k2[type]*sin(dphi2) +
-      3.0*d_k3[type]*sin(dphi3);
+  const F_FLOAT de_dihedral = d_k1[type]*Kokkos::Experimental::sin(dphi1) + 2.0*d_k2[type]*Kokkos::Experimental::sin(dphi2) +
+      3.0*d_k3[type]*Kokkos::Experimental::sin(dphi3);
 
   // torsion forces on all 4 atoms
 
@@ -449,8 +449,8 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // mid-bond/torsion coupling
   // energy on bond2 (middle bond)
 
-  F_FLOAT cos2phi = cos(2.0*phi);
-  F_FLOAT cos3phi = cos(3.0*phi);
+  F_FLOAT cos2phi = Kokkos::Experimental::cos(2.0*phi);
+  F_FLOAT cos3phi = Kokkos::Experimental::cos(3.0*phi);
 
   F_FLOAT bt1 = d_mbt_f1[type] * cosphi;
   F_FLOAT bt2 = d_mbt_f2[type] * cos2phi;
@@ -462,8 +462,8 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // force on bond2
 
   bt1 = -d_mbt_f1[type] * sinphi;
-  bt2 = -2.0 * d_mbt_f2[type] * sin(2.0*phi);
-  bt3 = -3.0 * d_mbt_f3[type] * sin(3.0*phi);
+  bt2 = -2.0 * d_mbt_f2[type] * Kokkos::Experimental::sin(2.0*phi);
+  bt3 = -3.0 * d_mbt_f3[type] * Kokkos::Experimental::sin(3.0*phi);
   F_FLOAT sumbtf = bt1 + bt2 + bt3;
 
   for (int i = 0; i < 4; i++)
@@ -484,8 +484,8 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // force on bond1
 
   bt1 = d_ebt_f1_1[type] * sinphi;
-  bt2 = 2.0 * d_ebt_f2_1[type] * sin(2.0*phi);
-  bt3 = 3.0 * d_ebt_f3_1[type] * sin(3.0*phi);
+  bt2 = 2.0 * d_ebt_f2_1[type] * Kokkos::Experimental::sin(2.0*phi);
+  bt3 = 3.0 * d_ebt_f3_1[type] * Kokkos::Experimental::sin(3.0*phi);
   sumbtf = bt1 + bt2 + bt3;
 
   for (int i = 0; i < 4; i++)
@@ -506,8 +506,8 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   // force on bond3
 
   bt1 = -d_ebt_f1_2[type] * sinphi;
-  bt2 = -2.0 * d_ebt_f2_2[type] * sin(2.0*phi);
-  bt3 = -3.0 * d_ebt_f3_2[type] * sin(3.0*phi);
+  bt2 = -2.0 * d_ebt_f2_2[type] * Kokkos::Experimental::sin(2.0*phi);
+  bt3 = -3.0 * d_ebt_f3_2[type] * Kokkos::Experimental::sin(3.0*phi);
   sumbtf = bt1 + bt2 + bt3;
 
   for (int i = 0; i < 4; i++)
@@ -522,14 +522,14 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   F_FLOAT at3 = d_at_f3_1[type] * cos3phi;
   sumbte = at1 + at2 + at3;
 
-  F_FLOAT da = acos(costh12) - d_at_theta0_1[type];
+  F_FLOAT da = Kokkos::Experimental::acos(costh12) - d_at_theta0_1[type];
   if (eflag) edihedral += da * (at1+at2+at3);
 
   // force on angle1
 
   bt1 = d_at_f1_1[type] * sinphi;
-  bt2 = 2.0 * d_at_f2_1[type] * sin(2.0*phi);
-  bt3 = 3.0 * d_at_f3_1[type] * sin(3.0*phi);
+  bt2 = 2.0 * d_at_f2_1[type] * Kokkos::Experimental::sin(2.0*phi);
+  bt3 = 3.0 * d_at_f3_1[type] * Kokkos::Experimental::sin(3.0*phi);
   sumbtf = bt1 + bt2 + bt3;
 
   for (int i = 0; i < 4; i++)
@@ -543,14 +543,14 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
   at3 = d_at_f3_2[type] * cos3phi;
   sumbte = at1 + at2 + at3;
 
-  da = acos(costh23) - d_at_theta0_2[type];
+  da = Kokkos::Experimental::acos(costh23) - d_at_theta0_2[type];
   if (eflag) edihedral += da * (at1+at2+at3);
 
   // force on angle2
 
   bt1 = -d_at_f1_2[type] * sinphi;
-  bt2 = -2.0 * d_at_f2_2[type] * sin(2.0*phi);
-  bt3 = -3.0 * d_at_f3_2[type] * sin(3.0*phi);
+  bt2 = -2.0 * d_at_f2_2[type] * Kokkos::Experimental::sin(2.0*phi);
+  bt3 = -3.0 * d_at_f3_2[type] * Kokkos::Experimental::sin(3.0*phi);
   sumbtf = bt1 + bt2 + bt3;
 
   for (int i = 0; i < 4; i++)
@@ -559,8 +559,8 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
 
   // angle/angle/torsion coupling
 
-  const F_FLOAT da1 = acos(costh12) - d_aat_theta0_1[type];
-  const F_FLOAT da2 = acos(costh23) - d_aat_theta0_2[type];
+  const F_FLOAT da1 = Kokkos::Experimental::acos(costh12) - d_aat_theta0_1[type];
+  const F_FLOAT da2 = Kokkos::Experimental::acos(costh23) - d_aat_theta0_2[type];
 
   if (eflag) edihedral += d_aat_k[type]*da1*da2*cosphi;
 
@@ -572,7 +572,7 @@ void DihedralClass2Kokkos<DeviceType>::operator()(TagDihedralClass2Compute<NEWTO
 
   // bond1/bond3 coupling
 
-  if (fabs(d_bb13t_k[type]) > SMALL) {
+  if (Kokkos::Experimental::fabs(d_bb13t_k[type]) > SMALL) {
 
     const F_FLOAT r1_0 = d_bb13t_r10[type];
     const F_FLOAT r3_0 = d_bb13t_r30[type];

--- a/src/KOKKOS/dihedral_harmonic_kokkos.cpp
+++ b/src/KOKKOS/dihedral_harmonic_kokkos.cpp
@@ -202,14 +202,14 @@ void DihedralHarmonicKokkos<DeviceType>::operator()(TagDihedralHarmonicCompute<N
   const F_FLOAT rasq = ax*ax + ay*ay + az*az;
   const F_FLOAT rbsq = bx*bx + by*by + bz*bz;
   const F_FLOAT rgsq = vb2xm*vb2xm + vb2ym*vb2ym + vb2zm*vb2zm;
-  const F_FLOAT rg = sqrt(rgsq);
+  const F_FLOAT rg = Kokkos::Experimental::sqrt(rgsq);
 
   F_FLOAT rginv,ra2inv,rb2inv;
   rginv = ra2inv = rb2inv = 0.0;
   if (rg > 0) rginv = 1.0/rg;
   if (rasq > 0) ra2inv = 1.0/rasq;
   if (rbsq > 0) rb2inv = 1.0/rbsq;
-  const F_FLOAT rabinv = sqrt(ra2inv*rb2inv);
+  const F_FLOAT rabinv = Kokkos::Experimental::sqrt(ra2inv*rb2inv);
 
   F_FLOAT c = (ax*bx + ay*by + az*bz)*rabinv;
   const F_FLOAT s = rg*rabinv*(ax*vb3x + ay*vb3y + az*vb3z);

--- a/src/KOKKOS/dihedral_opls_kokkos.cpp
+++ b/src/KOKKOS/dihedral_opls_kokkos.cpp
@@ -195,19 +195,19 @@ void DihedralOPLSKokkos<DeviceType>::operator()(TagDihedralOPLSCompute<NEWTON_BO
   const F_FLOAT sb2 = 1.0 / (vb2x*vb2x + vb2y*vb2y + vb2z*vb2z);
   const F_FLOAT sb3 = 1.0 / (vb3x*vb3x + vb3y*vb3y + vb3z*vb3z);
 
-  const F_FLOAT rb1 = sqrt(sb1);
-  const F_FLOAT rb3 = sqrt(sb3);
+  const F_FLOAT rb1 = Kokkos::Experimental::sqrt(sb1);
+  const F_FLOAT rb3 = Kokkos::Experimental::sqrt(sb3);
 
   const F_FLOAT c0 = (vb1x*vb3x + vb1y*vb3y + vb1z*vb3z) * rb1*rb3;
 
   // 1st and 2nd angle
 
   const F_FLOAT b1mag2 = vb1x*vb1x + vb1y*vb1y + vb1z*vb1z;
-  const F_FLOAT b1mag = sqrt(b1mag2);
+  const F_FLOAT b1mag = Kokkos::Experimental::sqrt(b1mag2);
   const F_FLOAT b2mag2 = vb2x*vb2x + vb2y*vb2y + vb2z*vb2z;
-  const F_FLOAT b2mag = sqrt(b2mag2);
+  const F_FLOAT b2mag = Kokkos::Experimental::sqrt(b2mag2);
   const F_FLOAT b3mag2 = vb3x*vb3x + vb3y*vb3y + vb3z*vb3z;
-  const F_FLOAT b3mag = sqrt(b3mag2);
+  const F_FLOAT b3mag = Kokkos::Experimental::sqrt(b3mag2);
 
   F_FLOAT ctmp = vb1x*vb2x + vb1y*vb2y + vb1z*vb2z;
   const F_FLOAT r12c1 = 1.0 / (b1mag*b2mag);
@@ -220,12 +220,12 @@ void DihedralOPLSKokkos<DeviceType>::operator()(TagDihedralOPLSCompute<NEWTON_BO
   // cos and sin of 2 angles and final c
 
   F_FLOAT sin2 = MAX(1.0 - c1mag*c1mag,0.0);
-  F_FLOAT sc1 = sqrt(sin2);
+  F_FLOAT sc1 = Kokkos::Experimental::sqrt(sin2);
   if (sc1 < SMALL) sc1 = SMALL;
   sc1 = 1.0/sc1;
 
   sin2 = MAX(1.0 - c2mag*c2mag,0.0);
-  F_FLOAT sc2 = sqrt(sin2);
+  F_FLOAT sc2 = Kokkos::Experimental::sqrt(sin2);
   if (sc2 < SMALL) sc2 = SMALL;
   sc2 = 1.0/sc2;
 
@@ -237,7 +237,7 @@ void DihedralOPLSKokkos<DeviceType>::operator()(TagDihedralOPLSCompute<NEWTON_BO
   const F_FLOAT cx = vb1y*vb2z - vb1z*vb2y;
   const F_FLOAT cy = vb1z*vb2x - vb1x*vb2z;
   const F_FLOAT cz = vb1x*vb2y - vb1y*vb2x;
-  const F_FLOAT cmag = sqrt(cx*cx + cy*cy + cz*cz);
+  const F_FLOAT cmag = Kokkos::Experimental::sqrt(cx*cx + cy*cy + cz*cz);
   const F_FLOAT dx = (cx*vb3x + cy*vb3y + cz*vb3z)/cmag/b3mag;
 
   // error check
@@ -249,19 +249,19 @@ void DihedralOPLSKokkos<DeviceType>::operator()(TagDihedralOPLSCompute<NEWTON_BO
   if (c < -1.0) c = -1.0;
 
   // force & energy
-  // p = sum (i=1,4) k_i * (1 + (-1)**(i+1)*cos(i*phi) )
+  // p = sum (i=1,4) k_i * (1 + (-1)**(i+1)*Kokkos::Experimental::cos(i*phi) )
   // pd = dp/dc
 
-  F_FLOAT phi = acos(c);
+  F_FLOAT phi = Kokkos::Experimental::acos(c);
   if (dx < 0.0) phi *= -1.0;
-  F_FLOAT si = sin(phi);
-  if (fabs(si) < SMALLER) si = SMALLER;
+  F_FLOAT si = Kokkos::Experimental::sin(phi);
+  if (Kokkos::Experimental::fabs(si) < SMALLER) si = SMALLER;
   const F_FLOAT siinv = 1.0/si;
 
-  const F_FLOAT p = d_k1[type]*(1.0 + c) + d_k2[type]*(1.0 - cos(2.0*phi)) +
-    d_k3[type]*(1.0 + cos(3.0*phi)) + d_k4[type]*(1.0 - cos(4.0*phi)) ;
-  const F_FLOAT pd = d_k1[type] - 2.0*d_k2[type]*sin(2.0*phi)*siinv +
-    3.0*d_k3[type]*sin(3.0*phi)*siinv - 4.0*d_k4[type]*sin(4.0*phi)*siinv;
+  const F_FLOAT p = d_k1[type]*(1.0 + c) + d_k2[type]*(1.0 - Kokkos::Experimental::cos(2.0*phi)) +
+    d_k3[type]*(1.0 + Kokkos::Experimental::cos(3.0*phi)) + d_k4[type]*(1.0 - Kokkos::Experimental::cos(4.0*phi)) ;
+  const F_FLOAT pd = d_k1[type] - 2.0*d_k2[type]*Kokkos::Experimental::sin(2.0*phi)*siinv +
+    3.0*d_k3[type]*Kokkos::Experimental::sin(3.0*phi)*siinv - 4.0*d_k4[type]*Kokkos::Experimental::sin(4.0*phi)*siinv;
 
   E_FLOAT edihedral = 0.0;
   if (eflag) edihedral = p;

--- a/src/KOKKOS/fft3d_kokkos.cpp
+++ b/src/KOKKOS/fft3d_kokkos.cpp
@@ -787,7 +787,7 @@ void FFT3dKokkos<DeviceType>::bifactor(int n, int *factor1, int *factor2)
 {
   int n1,n2,facmax;
 
-  facmax = static_cast<int> (sqrt((double) n));
+  facmax = static_cast<int> (Kokkos::Experimental::sqrt((double) n));
 
   for (n1 = facmax; n1 > 0; n1--) {
     n2 = n/n1;

--- a/src/KOKKOS/fix_deform_kokkos.cpp
+++ b/src/KOKKOS/fix_deform_kokkos.cpp
@@ -112,19 +112,19 @@ void FixDeformKokkos::end_of_step()
     } else if (set[i].style == TRATE) {
       double delt = (update->ntimestep - update->beginstep) * update->dt;
       set[i].lo_target = 0.5*(set[i].lo_start+set[i].hi_start) -
-        0.5*((set[i].hi_start-set[i].lo_start) * exp(set[i].rate*delt));
+        0.5*((set[i].hi_start-set[i].lo_start) * Kokkos::Experimental::exp(set[i].rate*delt));
       set[i].hi_target = 0.5*(set[i].lo_start+set[i].hi_start) +
-        0.5*((set[i].hi_start-set[i].lo_start) * exp(set[i].rate*delt));
+        0.5*((set[i].hi_start-set[i].lo_start) * Kokkos::Experimental::exp(set[i].rate*delt));
       h_rate[i] = set[i].rate * domain->h[i];
       h_ratelo[i] = -0.5*h_rate[i];
     } else if (set[i].style == WIGGLE) {
       double delt = (update->ntimestep - update->beginstep) * update->dt;
       set[i].lo_target = set[i].lo_start -
-        0.5*set[i].amplitude * sin(TWOPI*delt/set[i].tperiod);
+        0.5*set[i].amplitude * Kokkos::Experimental::sin(TWOPI*delt/set[i].tperiod);
       set[i].hi_target = set[i].hi_start +
-        0.5*set[i].amplitude * sin(TWOPI*delt/set[i].tperiod);
+        0.5*set[i].amplitude * Kokkos::Experimental::sin(TWOPI*delt/set[i].tperiod);
       h_rate[i] = TWOPI/set[i].tperiod * set[i].amplitude *
-        cos(TWOPI*delt/set[i].tperiod);
+        Kokkos::Experimental::cos(TWOPI*delt/set[i].tperiod);
       h_ratelo[i] = -0.5*h_rate[i];
     } else if (set[i].style == VARIABLE) {
       double del = input->variable->compute_equal(set[i].hvar);
@@ -174,14 +174,14 @@ void FixDeformKokkos::end_of_step()
 
     } else if (set[i].substyle == TWO_FROM_ONE) {
       set[i].lo_target = 0.5*(set[i].lo_start+set[i].hi_start) -
-        0.5*sqrt(set[i].vol_start /
+        0.5*Kokkos::Experimental::sqrt(set[i].vol_start /
                  (set[set[i].dynamic1].hi_target -
                   set[set[i].dynamic1].lo_target) /
                  (set[set[i].fixed].hi_start -
                   set[set[i].fixed].lo_start) *
                  (set[i].hi_start - set[i].lo_start));
       set[i].hi_target = 0.5*(set[i].lo_start+set[i].hi_start) +
-        0.5*sqrt(set[i].vol_start /
+        0.5*Kokkos::Experimental::sqrt(set[i].vol_start /
                  (set[set[i].dynamic1].hi_target -
                   set[set[i].dynamic1].lo_target) /
                  (set[set[i].fixed].hi_start -
@@ -207,14 +207,14 @@ void FixDeformKokkos::end_of_step()
         else if (i == 3) set[i].tilt_target = domain->yz;
       } else if (set[i].style == TRATE) {
         double delt = (update->ntimestep - update->beginstep) * update->dt;
-        set[i].tilt_target = set[i].tilt_start * exp(set[i].rate*delt);
+        set[i].tilt_target = set[i].tilt_start * Kokkos::Experimental::exp(set[i].rate*delt);
         h_rate[i] = set[i].rate * domain->h[i];
       } else if (set[i].style == WIGGLE) {
         double delt = (update->ntimestep - update->beginstep) * update->dt;
         set[i].tilt_target = set[i].tilt_start +
-          set[i].amplitude * sin(TWOPI*delt/set[i].tperiod);
+          set[i].amplitude * Kokkos::Experimental::sin(TWOPI*delt/set[i].tperiod);
         h_rate[i] = TWOPI/set[i].tperiod * set[i].amplitude *
-          cos(TWOPI*delt/set[i].tperiod);
+          Kokkos::Experimental::cos(TWOPI*delt/set[i].tperiod);
       } else if (set[i].style == VARIABLE) {
         double delta_tilt = input->variable->compute_equal(set[i].hvar);
         set[i].tilt_target = set[i].tilt_start + delta_tilt;
@@ -239,8 +239,8 @@ void FixDeformKokkos::end_of_step()
         set[i].tilt_target -= denom;
       while (set[i].tilt_target/denom - current < 0.0)
         set[i].tilt_target += denom;
-      if (fabs(set[i].tilt_target/denom - 1.0 - current) <
-          fabs(set[i].tilt_target/denom - current))
+      if (Kokkos::Experimental::fabs(set[i].tilt_target/denom - 1.0 - current) <
+          Kokkos::Experimental::fabs(set[i].tilt_target/denom - current))
         set[i].tilt_target -= denom;
     }
   }

--- a/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_eos_table_rx_kokkos.cpp
@@ -306,7 +306,7 @@ void FixEOStableRXKokkos<DeviceType>::energy_lookup(int id, double thetai, doubl
   if (rx_flag) {
     for (int ispecies = 0; ispecies < nspecies; ispecies++) {
       nTotal += dvector(ispecies,id);
-      if (fabs(d_moleculeCorrCoeff[ispecies]) > tolerance) {
+      if (Kokkos::Experimental::fabs(d_moleculeCorrCoeff[ispecies]) > tolerance) {
         nPG++;
         nTotalPG += dvector(ispecies,id);
       }
@@ -384,7 +384,7 @@ void FixEOStableRXKokkos<DeviceType>::temperature_lookup(int id, double ui, doub
 
   // Apply the Secant Method
   for (it=0; it<maxit; it++) {
-    if (fabs(f2-f1) < MY_EPSILON) {
+    if (Kokkos::Experimental::fabs(f2-f1) < MY_EPSILON) {
       if (std::isnan(f1) || std::isnan(f2)) k_error_flag.template view<DeviceType>()() = 2;
       temp = t1;
       temp = MAX(temp,lo);
@@ -393,7 +393,7 @@ void FixEOStableRXKokkos<DeviceType>::temperature_lookup(int id, double ui, doub
       break;
     }
     temp = t2 - f2*(t2-t1)/(f2-f1);
-    if (fabs(temp-t2) < tolerance) break;
+    if (Kokkos::Experimental::fabs(temp-t2) < tolerance) break;
     f1 = f2;
     t1 = t2;
     t2 = temp;

--- a/src/KOKKOS/fix_langevin_kokkos.cpp
+++ b/src/KOKKOS/fix_langevin_kokkos.cpp
@@ -190,7 +190,7 @@ void FixLangevinKokkos<DeviceType>::post_force(int /*vflag*/)
   dt = update->dt;
   mvv2e = force->mvv2e;
   ftm2v = force->ftm2v;
-  fran_prop_const = sqrt(24.0*boltz/t_period/dt/mvv2e);
+  fran_prop_const = Kokkos::Experimental::sqrt(24.0*boltz/t_period/dt/mvv2e);
 
   compute_target(); // modifies tforce vector, hence sync here
   k_tforce.template sync<DeviceType>();
@@ -567,12 +567,12 @@ FSUM FixLangevinKokkos<DeviceType>::post_force_item(int i) const
 
   if (mask[i] & groupbit) {
     rand_type rand_gen = rand_pool.get_state();
-    if (Tp_TSTYLEATOM) tsqrt_t = sqrt(d_tforce[i]);
+    if (Tp_TSTYLEATOM) tsqrt_t = Kokkos::Experimental::sqrt(d_tforce[i]);
     if (Tp_RMASS) {
       gamma1 = -rmass[i] / t_period / ftm2v;
-      gamma2 = sqrt(rmass[i]) * fran_prop_const / ftm2v;
+      gamma2 = Kokkos::Experimental::sqrt(rmass[i]) * fran_prop_const / ftm2v;
       gamma1 *= 1.0/d_ratio[type[i]];
-      gamma2 *= 1.0/sqrt(d_ratio[type[i]]) * tsqrt_t;
+      gamma2 *= 1.0/Kokkos::Experimental::sqrt(d_ratio[type[i]]) * tsqrt_t;
     } else {
       gamma1 = d_gfactor1[type[i]];
       gamma2 = d_gfactor2[type[i]] * tsqrt_t;
@@ -686,14 +686,14 @@ void FixLangevinKokkos<DeviceType>::compute_target()
 
   if (tstyle == CONSTANT) {
     t_target = t_start + delta * (t_stop-t_start);
-    tsqrt = sqrt(t_target);
+    tsqrt = Kokkos::Experimental::sqrt(t_target);
   } else {
     modify->clearstep_compute();
     if (tstyle == EQUAL) {
       t_target = input->variable->compute_equal(tvar);
       if (t_target < 0.0)
         error->one(FLERR,"Fix langevin variable returned negative temperature");
-      tsqrt = sqrt(t_target);
+      tsqrt = Kokkos::Experimental::sqrt(t_target);
     } else {
       if (atom->nmax > maxatom2) {
         maxatom2 = atom->nmax;
@@ -721,10 +721,10 @@ void FixLangevinKokkos<DeviceType>::reset_dt()
 {
   if (atomKK->mass) {
     for (int i = 1; i <= atomKK->ntypes; i++) {
-      h_gfactor2[i] = sqrt(atomKK->mass[i]) *
-        sqrt(24.0*force->boltz/t_period/update->dt/force->mvv2e) /
+      h_gfactor2[i] = Kokkos::Experimental::sqrt(atomKK->mass[i]) *
+        Kokkos::Experimental::sqrt(24.0*force->boltz/t_period/update->dt/force->mvv2e) /
         force->ftm2v;
-      h_gfactor2[i] *= 1.0/sqrt(h_ratio[i]);
+      h_gfactor2[i] *= 1.0/Kokkos::Experimental::sqrt(h_ratio[i]);
     }
     k_gfactor2.template modify<LMPHostType>();
   }

--- a/src/KOKKOS/fix_minimize_kokkos.cpp
+++ b/src/KOKKOS/fix_minimize_kokkos.cpp
@@ -122,19 +122,19 @@ void FixMinimizeKokkos::reset_coords()
       {
         if (triclinic == 0) {
           if (xperiodic) {
-            if (fabs(dx) > xprd_half) {
+            if (Kokkos::Experimental::fabs(dx) > xprd_half) {
               if (dx < 0.0) dx += xprd;
               else dx -= xprd;
             }
           }
           if (yperiodic) {
-            if (fabs(dy) > yprd_half) {
+            if (Kokkos::Experimental::fabs(dy) > yprd_half) {
               if (dy < 0.0) dy += yprd;
               else dy -= yprd;
             }
           }
           if (zperiodic) {
-            if (fabs(dz) > zprd_half) {
+            if (Kokkos::Experimental::fabs(dz) > zprd_half) {
               if (dz < 0.0) dz += zprd;
               else dz -= zprd;
             }
@@ -142,7 +142,7 @@ void FixMinimizeKokkos::reset_coords()
 
         } else {
           if (zperiodic) {
-            if (fabs(dz) > zprd_half) {
+            if (Kokkos::Experimental::fabs(dz) > zprd_half) {
               if (dz < 0.0) {
                 dz += zprd;
                 dy += yz;
@@ -155,7 +155,7 @@ void FixMinimizeKokkos::reset_coords()
             }
           }
           if (yperiodic) {
-            if (fabs(dy) > yprd_half) {
+            if (Kokkos::Experimental::fabs(dy) > yprd_half) {
               if (dy < 0.0) {
                 dy += yprd;
                 dx += xy;
@@ -166,7 +166,7 @@ void FixMinimizeKokkos::reset_coords()
             }
           }
           if (xperiodic) {
-            if (fabs(dx) > xprd_half) {
+            if (Kokkos::Experimental::fabs(dx) > xprd_half) {
               if (dx < 0.0) dx += xprd;
               else dx -= xprd;
             }

--- a/src/KOKKOS/fix_momentum_kokkos.cpp
+++ b/src/KOKKOS/fix_momentum_kokkos.cpp
@@ -189,7 +189,7 @@ void FixMomentumKokkos<DeviceType>::end_of_step()
     ekin_new = get_kinetic_energy<DeviceType>(atomKK, world, groupbit, nlocal, v, mask);
 
     double factor = 1.0;
-    if (ekin_new != 0.0) factor = sqrt(ekin_old/ekin_new);
+    if (ekin_new != 0.0) factor = Kokkos::Experimental::sqrt(ekin_old/ekin_new);
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),
      LAMMPS_LAMBDA(int i) {
       if (mask(i) & groupbit2) {

--- a/src/KOKKOS/fix_nh_kokkos.cpp
+++ b/src/KOKKOS/fix_nh_kokkos.cpp
@@ -343,28 +343,28 @@ void FixNHKokkos<DeviceType>::remap()
   if (pstyle == TRICLINIC) {
 
     if (p_flag[4]) {
-      expfac = exp(dto8*omega_dot[0]);
+      expfac = Kokkos::Experimental::exp(dto8*omega_dot[0]);
       h[4] *= expfac;
       h[4] += dto4*(omega_dot[5]*h[3]+omega_dot[4]*h[2]);
       h[4] *= expfac;
     }
 
     if (p_flag[3]) {
-      expfac = exp(dto4*omega_dot[1]);
+      expfac = Kokkos::Experimental::exp(dto4*omega_dot[1]);
       h[3] *= expfac;
       h[3] += dto2*(omega_dot[3]*h[2]);
       h[3] *= expfac;
     }
 
     if (p_flag[5]) {
-      expfac = exp(dto4*omega_dot[0]);
+      expfac = Kokkos::Experimental::exp(dto4*omega_dot[0]);
       h[5] *= expfac;
       h[5] += dto2*(omega_dot[5]*h[1]);
       h[5] *= expfac;
     }
 
     if (p_flag[4]) {
-      expfac = exp(dto8*omega_dot[0]);
+      expfac = Kokkos::Experimental::exp(dto8*omega_dot[0]);
       h[4] *= expfac;
       h[4] += dto4*(omega_dot[5]*h[3]+omega_dot[4]*h[2]);
       h[4] *= expfac;
@@ -377,7 +377,7 @@ void FixNHKokkos<DeviceType>::remap()
   if (p_flag[0]) {
     oldlo = domain->boxlo[0];
     oldhi = domain->boxhi[0];
-    expfac = exp(dto*omega_dot[0]);
+    expfac = Kokkos::Experimental::exp(dto*omega_dot[0]);
     domain->boxlo[0] = (oldlo-fixedpoint[0])*expfac + fixedpoint[0];
     domain->boxhi[0] = (oldhi-fixedpoint[0])*expfac + fixedpoint[0];
   }
@@ -385,7 +385,7 @@ void FixNHKokkos<DeviceType>::remap()
   if (p_flag[1]) {
     oldlo = domain->boxlo[1];
     oldhi = domain->boxhi[1];
-    expfac = exp(dto*omega_dot[1]);
+    expfac = Kokkos::Experimental::exp(dto*omega_dot[1]);
     domain->boxlo[1] = (oldlo-fixedpoint[1])*expfac + fixedpoint[1];
     domain->boxhi[1] = (oldhi-fixedpoint[1])*expfac + fixedpoint[1];
     if (scalexy) h[5] *= expfac;
@@ -394,7 +394,7 @@ void FixNHKokkos<DeviceType>::remap()
   if (p_flag[2]) {
     oldlo = domain->boxlo[2];
     oldhi = domain->boxhi[2];
-    expfac = exp(dto*omega_dot[2]);
+    expfac = Kokkos::Experimental::exp(dto*omega_dot[2]);
     domain->boxlo[2] = (oldlo-fixedpoint[2])*expfac + fixedpoint[2];
     domain->boxhi[2] = (oldhi-fixedpoint[2])*expfac + fixedpoint[2];
     if (scalexz) h[4] *= expfac;
@@ -406,28 +406,28 @@ void FixNHKokkos<DeviceType>::remap()
   if (pstyle == TRICLINIC) {
 
     if (p_flag[4]) {
-      expfac = exp(dto8*omega_dot[0]);
+      expfac = Kokkos::Experimental::exp(dto8*omega_dot[0]);
       h[4] *= expfac;
       h[4] += dto4*(omega_dot[5]*h[3]+omega_dot[4]*h[2]);
       h[4] *= expfac;
     }
 
     if (p_flag[3]) {
-      expfac = exp(dto4*omega_dot[1]);
+      expfac = Kokkos::Experimental::exp(dto4*omega_dot[1]);
       h[3] *= expfac;
       h[3] += dto2*(omega_dot[3]*h[2]);
       h[3] *= expfac;
     }
 
     if (p_flag[5]) {
-      expfac = exp(dto4*omega_dot[0]);
+      expfac = Kokkos::Experimental::exp(dto4*omega_dot[0]);
       h[5] *= expfac;
       h[5] += dto2*(omega_dot[5]*h[1]);
       h[5] *= expfac;
     }
 
     if (p_flag[4]) {
-      expfac = exp(dto8*omega_dot[0]);
+      expfac = Kokkos::Experimental::exp(dto8*omega_dot[0]);
       h[4] *= expfac;
       h[4] += dto4*(omega_dot[5]*h[3]+omega_dot[4]*h[2]);
       h[4] *= expfac;
@@ -480,9 +480,9 @@ void FixNHKokkos<DeviceType>::nh_v_press()
   int nlocal = atomKK->nlocal;
   if (igroup == atomKK->firstgroup) nlocal = atomKK->nfirst;
 
-  factor[0] = exp(-dt4*(omega_dot[0]+mtk_term2));
-  factor[1] = exp(-dt4*(omega_dot[1]+mtk_term2));
-  factor[2] = exp(-dt4*(omega_dot[2]+mtk_term2));
+  factor[0] = Kokkos::Experimental::exp(-dt4*(omega_dot[0]+mtk_term2));
+  factor[1] = Kokkos::Experimental::exp(-dt4*(omega_dot[1]+mtk_term2));
+  factor[2] = Kokkos::Experimental::exp(-dt4*(omega_dot[2]+mtk_term2));
 
   if (which == BIAS) {
     atomKK->sync(temperature->execution_space,temperature->datamask_read);

--- a/src/KOKKOS/fix_qeq_reax_kokkos.cpp
+++ b/src/KOKKOS/fix_qeq_reax_kokkos.cpp
@@ -141,7 +141,7 @@ void FixQEqReaxKokkos<DeviceType>::init_shielding_k()
 
   for (i = 1; i <= ntypes; ++i)
     for (j = 1; j <= ntypes; ++j)
-      k_shield.h_view(i,j) = pow( gamma[i] * gamma[j], -1.5 );
+      k_shield.h_view(i,j) = Kokkos::Experimental::pow( gamma[i] * gamma[j], -1.5 );
 
   k_shield.template modify<LMPHostType>();
   k_shield.template sync<DeviceType>();
@@ -454,7 +454,7 @@ void FixQEqReaxKokkos<DeviceType>::compute_h_item(int ii, int &m_fill, const boo
       if (rsq > cutsq) continue;
 
       if (final) {
-        const F_FLOAT r = sqrt(rsq);
+        const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
         d_jlist(m_fill) = j;
         const F_FLOAT shldij = d_shield(itype,jtype);
         d_val(m_fill) = calculate_H_k(r,shldij);
@@ -640,7 +640,7 @@ void FixQEqReaxKokkos<DeviceType>::compute_h_team(
                       if (valid) {
                         s_jlist(team.team_rank(), idx) = j;
                         s_jtype(team.team_rank(), idx) = jtype;
-                        s_r(team.team_rank(), idx) = sqrt(rsq);
+                        s_r(team.team_rank(), idx) = Kokkos::Experimental::sqrt(rsq);
                         m_fill++;
                       }
                     }
@@ -695,7 +695,7 @@ double FixQEqReaxKokkos<DeviceType>::calculate_H_k(const F_FLOAT &r, const F_FLO
   taper = taper * r + d_tap[0];
 
   denom = r * r * r + shld;
-  denom = pow(denom,0.3333333333333);
+  denom = Kokkos::Experimental::pow(denom,0.3333333333333);
 
   return taper * EV_TO_KCAL_PER_MOL / denom;
 }
@@ -764,7 +764,7 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve1()
   Kokkos::parallel_reduce(inum,norm1_functor,my_norm);
   F_FLOAT norm_sqr = 0.0;
   MPI_Allreduce( &my_norm, &norm_sqr, 1, MPI_DOUBLE, MPI_SUM, world );
-  b_norm = sqrt(norm_sqr);
+  b_norm = Kokkos::Experimental::sqrt(norm_sqr);
 
   // sig_new = parallel_dot( r, d, nn);
   F_FLOAT my_dot = 0.0;
@@ -775,7 +775,7 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve1()
   F_FLOAT sig_new = dot_sqr;
 
   int loop;
-  for (loop = 1; (loop < imax) && (sqrt(sig_new)/b_norm > tolerance); loop++) {
+  for (loop = 1; (loop < imax) && (Kokkos::Experimental::sqrt(sig_new)/b_norm > tolerance); loop++) {
 
     // comm->forward_comm_fix(this); //Dist_vector( d );
     pack_flag = 1;
@@ -842,7 +842,7 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve1()
   if (loop >= imax && comm->me == 0) {
     char str[128];
     sprintf(str,"Fix qeq/reax cg_solve1 convergence failed after %d iterations "
-            "at " BIGINT_FORMAT " step: %f",loop,update->ntimestep,sqrt(sig_new)/b_norm);
+            "at " BIGINT_FORMAT " step: %f",loop,update->ntimestep,Kokkos::Experimental::sqrt(sig_new)/b_norm);
     error->warning(FLERR,str);
     //error->all(FLERR,str);
   }
@@ -896,7 +896,7 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve2()
   Kokkos::parallel_reduce(inum,norm2_functor,my_norm);
   F_FLOAT norm_sqr = 0.0;
   MPI_Allreduce( &my_norm, &norm_sqr, 1, MPI_DOUBLE, MPI_SUM, world );
-  b_norm = sqrt(norm_sqr);
+  b_norm = Kokkos::Experimental::sqrt(norm_sqr);
 
   // sig_new = parallel_dot( r, d, nn);
   F_FLOAT my_dot = 0.0;
@@ -907,7 +907,7 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve2()
   F_FLOAT sig_new = dot_sqr;
 
   int loop;
-  for (loop = 1; (loop < imax) && (sqrt(sig_new)/b_norm > tolerance); loop++) {
+  for (loop = 1; (loop < imax) && (Kokkos::Experimental::sqrt(sig_new)/b_norm > tolerance); loop++) {
 
     // comm->forward_comm_fix(this); //Dist_vector( d );
     pack_flag = 1;
@@ -974,7 +974,7 @@ void FixQEqReaxKokkos<DeviceType>::cg_solve2()
   if (loop >= imax && comm->me == 0) {
     char str[128];
     sprintf(str,"Fix qeq/reax cg_solve2 convergence failed after %d iterations "
-            "at " BIGINT_FORMAT " step: %f",loop,update->ntimestep,sqrt(sig_new)/b_norm);
+            "at " BIGINT_FORMAT " step: %f",loop,update->ntimestep,Kokkos::Experimental::sqrt(sig_new)/b_norm);
     error->warning(FLERR,str);
     //error->all(FLERR,str);
   }

--- a/src/KOKKOS/fix_rx_kokkos.cpp
+++ b/src/KOKKOS/fix_rx_kokkos.cpp
@@ -375,7 +375,7 @@ void FixRxKokkos<DeviceType>::k_rkf45_step (const int neq, const double h, Vecto
       const double r4 = a1*f1[k] + a3*f3[k] + a4*f4[k] + a5*f5[k];
 
       // Truncation error: difference between 4th and 5th-order solutions.
-      rwk[k] = fabs(r5 - r4);
+      rwk[k] = Kokkos::Experimental::fabs(r5 - r4);
 
       // Update solution.
     //y_out[k] = y[k] + r5; // Local extrapolation
@@ -396,7 +396,7 @@ int FixRxKokkos<DeviceType>::k_rkf45_h0 (const int neq, const double t, const do
    // Exit with this value if the bounds cross each other.
 
    // Adjust upper bound based on ydot ...
-   double hg = sqrt(hmin*hmax);
+   double hg = Kokkos::Experimental::sqrt(hmin*hmax);
 
    //if (hmax < hmin)
    //{
@@ -432,11 +432,11 @@ int FixRxKokkos<DeviceType>::k_rkf45_h0 (const int neq, const double t, const do
       double yddnrm = 0.0;
       for (int k = 0; k < neq; k++) {
          double ydd = (ydot1[k] - ydot[k]) / hg;
-         double wterr = ydd / (relTol * fabs( y[k] ) + absTol);
+         double wterr = ydd / (relTol * Kokkos::Experimental::fabs( y[k] ) + absTol);
          yddnrm += wterr * wterr;
       }
 
-      yddnrm = sqrt( yddnrm / double(neq) );
+      yddnrm = Kokkos::Experimental::sqrt( yddnrm / double(neq) );
 
       //std::cout << "iter " << _iter << " hg " << hg << " y'' " << yddnrm << std::endl;
       //std::cout << "ydot " << ydot[neq-1] << std::endl;
@@ -450,7 +450,7 @@ int FixRxKokkos<DeviceType>::k_rkf45_h0 (const int neq, const double t, const do
       }
 
       // Get the new value of h ...
-      hnew = (yddnrm*hmax*hmax > 2.0) ? sqrt(2.0 / yddnrm) : sqrt(hg * hmax);
+      hnew = (yddnrm*hmax*hmax > 2.0) ? Kokkos::Experimental::sqrt(2.0 / yddnrm) : Kokkos::Experimental::sqrt(hg * hmax);
 
       // test the stopping conditions.
       double hrat = hnew / hg;
@@ -520,7 +520,7 @@ void FixRxKokkos<DeviceType>::k_rkf45(const int neq, const double t_stop, Vector
   //printf("t= %e t_stop= %e h= %e\n", t, t_stop, h);
 
   // Integrate until we reach the end time.
-  while (fabs(t - t_stop) > tround)
+  while (Kokkos::Experimental::fabs(t - t_stop) > tround)
   {
     VectorType& yout = rwork;
     VectorType  eout ( &yout[neq] );
@@ -532,11 +532,11 @@ void FixRxKokkos<DeviceType>::k_rkf45(const int neq, const double t_stop, Vector
       // ... weighted 2-norm of the error.
       double err2 = 0.0;
       for (int k = 0; k < neq; k++) {
-        const double wterr = eout[k] / (relTol * fabs( y[k] ) + absTol);
+        const double wterr = eout[k] / (relTol * Kokkos::Experimental::fabs( y[k] ) + absTol);
         err2 += wterr * wterr;
       }
 
-    double err = fmax( uround, sqrt( err2 / double(nspecies) ));
+    double err = fmax( uround, Kokkos::Experimental::sqrt( err2 / double(nspecies) ));
 
     // Accept the solution?
     if (err <= 1.0 || h <= h_min) {
@@ -548,7 +548,7 @@ void FixRxKokkos<DeviceType>::k_rkf45(const int neq, const double t_stop, Vector
     }
 
     // Adjust h for the next step.
-    double hfac = hsafe * sqrt( sqrt( 1.0 / err ) );
+    double hfac = hsafe * Kokkos::Experimental::sqrt( Kokkos::Experimental::sqrt( 1.0 / err ) );
 
     // Limit the adaption.
     hfac = fmax( hfac, 1.0 / adaption_limit );
@@ -696,7 +696,7 @@ void FixRxKokkos<DeviceType>::rkf45_step (const int neq, const double h, double 
       const double r4 = a1*f1[k] + a3*f3[k] + a4*f4[k] + a5*f5[k];
 
       // Truncation error: difference between 4th and 5th-order solutions.
-      rwk[k] = fabs(r5 - r4);
+      rwk[k] = Kokkos::Experimental::fabs(r5 - r4);
 
       // Update solution.
     //y_out[k] = y[k] + r5; // Local extrapolation
@@ -715,7 +715,7 @@ int FixRxKokkos<DeviceType>::rkf45_h0(const int neq, const double t, const doubl
    // Exit with this value if the bounds cross each other.
 
    // Adjust upper bound based on ydot ...
-   double hg = sqrt(hmin*hmax);
+   double hg = Kokkos::Experimental::sqrt(hmin*hmax);
 
    //if (hmax < hmin)
    //{
@@ -751,11 +751,11 @@ int FixRxKokkos<DeviceType>::rkf45_h0(const int neq, const double t, const doubl
       double yddnrm = 0.0;
       for (int k = 0; k < neq; k++) {
          double ydd = (ydot1[k] - ydot[k]) / hg;
-         double wterr = ydd / (relTol * fabs( y[k] ) + absTol);
+         double wterr = ydd / (relTol * Kokkos::Experimental::fabs( y[k] ) + absTol);
          yddnrm += wterr * wterr;
       }
 
-      yddnrm = sqrt( yddnrm / double(neq) );
+      yddnrm = Kokkos::Experimental::sqrt( yddnrm / double(neq) );
 
       //std::cout << "iter " << _iter << " hg " << hg << " y'' " << yddnrm << std::endl;
       //std::cout << "ydot " << ydot[neq-1] << std::endl;
@@ -769,7 +769,7 @@ int FixRxKokkos<DeviceType>::rkf45_h0(const int neq, const double t, const doubl
       }
 
       // Get the new value of h ...
-      hnew = (yddnrm*hmax*hmax > 2.0) ? sqrt(2.0 / yddnrm) : sqrt(hg * hmax);
+      hnew = (yddnrm*hmax*hmax > 2.0) ? Kokkos::Experimental::sqrt(2.0 / yddnrm) : Kokkos::Experimental::sqrt(hg * hmax);
 
       // test the stopping conditions.
       double hrat = hnew / hg;
@@ -837,7 +837,7 @@ void FixRxKokkos<DeviceType>::rkf45(const int neq, const double t_stop, double *
   //printf("t= %e t_stop= %e h= %e\n", t, t_stop, h);
 
   // Integrate until we reach the end time.
-  while (fabs(t - t_stop) > tround) {
+  while (Kokkos::Experimental::fabs(t - t_stop) > tround) {
     double *yout = rwork;
     double *eout = yout + neq;
 
@@ -848,11 +848,11 @@ void FixRxKokkos<DeviceType>::rkf45(const int neq, const double t_stop, double *
       // ... weighted 2-norm of the error.
       double err2 = 0.0;
       for (int k = 0; k < neq; k++) {
-        const double wterr = eout[k] / (relTol * fabs( y[k] ) + absTol);
+        const double wterr = eout[k] / (relTol * Kokkos::Experimental::fabs( y[k] ) + absTol);
         err2 += wterr * wterr;
       }
 
-    double err = fmax( uround, sqrt( err2 / double(nspecies) ));
+    double err = fmax( uround, Kokkos::Experimental::sqrt( err2 / double(nspecies) ));
 
     // Accept the solution?
     if (err <= 1.0 || h <= h_min) {
@@ -864,7 +864,7 @@ void FixRxKokkos<DeviceType>::rkf45(const int neq, const double t_stop, double *
     }
 
     // Adjust h for the next step.
-    double hfac = hsafe * sqrt( sqrt( 1.0 / err ) );
+    double hfac = hsafe * Kokkos::Experimental::sqrt( Kokkos::Experimental::sqrt( 1.0 / err ) );
 
     // Limit the adaption.
     hfac = fmax( hfac, 1.0 / adaption_limit );
@@ -938,8 +938,8 @@ int FixRxKokkos<DeviceType>::rhs_dense(double /*t*/, const double *y, double *dy
 
     for (int ispecies=0; ispecies<nspecies; ispecies++) {
       const double concentration = y[ispecies]/VDPD;
-      rxnRateLawForward *= pow( concentration, d_kineticsData.stoichReactants(jrxn,ispecies) );
-      //rxnRateLawForward *= pow(concentration,stoichReactants[jrxn][ispecies]);
+      rxnRateLawForward *= Kokkos::Experimental::pow( concentration, d_kineticsData.stoichReactants(jrxn,ispecies) );
+      //rxnRateLawForward *= Kokkos::Experimental::pow(concentration,stoichReactants[jrxn][ispecies]);
     }
     rxnRateLaw[jrxn] = rxnRateLawForward;
   }
@@ -992,12 +992,12 @@ int FixRxKokkos<DeviceType>::rhs_sparse(double /*t*/, const double *y, double *d
                rxnRateLawForward *= powint( conc[k], inu(i,kk) );
          }
       } else {
-         rxnRateLawForward = kFor[i] * pow( conc[ nuk(i,0) ], nu(i,0) );
+         rxnRateLawForward = kFor[i] * Kokkos::Experimental::pow( conc[ nuk(i,0) ], nu(i,0) );
          for (int kk = 1; kk < maxReactants; ++kk) {
             const int k = nuk(i,kk);
             if (k == SparseKinetics_invalidIndex) break;
             //if (k != SparseKinetics_invalidIndex)
-               rxnRateLawForward *= pow( conc[k], nu(i,kk) );
+               rxnRateLawForward *= Kokkos::Experimental::pow( conc[k], nu(i,kk) );
          }
       }
 
@@ -1084,8 +1084,8 @@ int FixRxKokkos<DeviceType>::k_rhs_dense(double /*t*/, const VectorType& y, Vect
 
     for (int ispecies=0; ispecies<nspecies; ispecies++) {
       const double concentration = y[ispecies]/VDPD;
-      rxnRateLawForward *= pow( concentration, d_kineticsData.stoichReactants(jrxn,ispecies) );
-      //rxnRateLawForward *= pow(concentration,stoichReactants[jrxn][ispecies]);
+      rxnRateLawForward *= Kokkos::Experimental::pow( concentration, d_kineticsData.stoichReactants(jrxn,ispecies) );
+      //rxnRateLawForward *= Kokkos::Experimental::pow(concentration,stoichReactants[jrxn][ispecies]);
     }
     rxnRateLaw[jrxn] = rxnRateLawForward;
   }
@@ -1139,12 +1139,12 @@ int FixRxKokkos<DeviceType>::k_rhs_sparse(double /*t*/, const VectorType& y, Vec
                rxnRateLawForward *= powint( conc[k], inu(i,kk) );
          }
       } else {
-         rxnRateLawForward = kFor[i] * pow( conc[ nuk(i,0) ], nu(i,0) );
+         rxnRateLawForward = kFor[i] * Kokkos::Experimental::pow( conc[ nuk(i,0) ], nu(i,0) );
          for (int kk = 1; kk < maxReactants; ++kk) {
             const int k = nuk(i,kk);
             if (k == SparseKinetics_invalidIndex) break;
             //if (k != SparseKinetics_invalidIndex)
-               rxnRateLawForward *= pow( conc[k], nu(i,kk) );
+               rxnRateLawForward *= Kokkos::Experimental::pow( conc[k], nu(i,kk) );
          }
       }
 
@@ -1220,7 +1220,7 @@ void FixRxKokkos<DeviceType>::operator()(SolverType, const int &i) const
       if (SolverType::setToZero)
         userData.kFor[irxn] = 0.0;
       else
-        userData.kFor[irxn] = Arr[irxn]*pow(theta,nArr[irxn])*exp(-Ea[irxn]/force->boltz/theta);
+        userData.kFor[irxn] = Arr[irxn]*Kokkos::Experimental::pow(theta,nArr[irxn])*Kokkos::Experimental::exp(-Ea[irxn]/force->boltz/theta);
     }
 
     if (odeIntegrationFlag == ODE_LAMMPS_RK4)
@@ -1376,8 +1376,8 @@ void FixRxKokkos<DeviceType>::operator()(Tag_FixRxKokkos_solveSystems<ZERO_RATES
       else
       {
         userData.kFor[irxn] = d_kineticsData.Arr(irxn) *
-                               pow(theta, d_kineticsData.nArr(irxn)) *
-                               exp(-d_kineticsData.Ea(irxn) / boltz / theta);
+                               Kokkos::Experimental::pow(theta, d_kineticsData.nArr(irxn)) *
+                               Kokkos::Experimental::exp(-d_kineticsData.Ea(irxn) / boltz / theta);
       }
     }
 
@@ -1595,8 +1595,8 @@ void FixRxKokkos<DeviceType>::solve_reactions(const int /*vflag*/, const bool is
           else
           {
             userData.kFor[irxn] = d_kineticsData.Arr(irxn) *
-                                   pow(theta, d_kineticsData.nArr(irxn)) *
-                                   exp(-d_kineticsData.Ea(irxn) / boltz / theta);
+                                   Kokkos::Experimental::pow(theta, d_kineticsData.nArr(irxn)) *
+                                   Kokkos::Experimental::exp(-d_kineticsData.Ea(irxn) / boltz / theta);
           }
         }
 
@@ -1853,7 +1853,7 @@ void FixRxKokkos<DeviceType>::odeDiagnostics(void)
     if (diagnosticFrequency == 1) {
       double rms_per_ODE[numCounters];
       for (int i = 0; i < numCounters; ++i)
-        rms_per_ODE[i] = sqrt( sum_sq[i+numCounters] / nODEs );
+        rms_per_ODE[i] = Kokkos::Experimental::sqrt( sum_sq[i+numCounters] / nODEs );
 
       sprintf(smesg, "         RMS per ODE  : %-12.5g | %-12.5g ", rms_per_ODE[0], rms_per_ODE[1]);
       print_mesg(smesg);
@@ -1871,7 +1871,7 @@ void FixRxKokkos<DeviceType>::odeDiagnostics(void)
     if (comm->nprocs > 1) {
       double rms_per_proc[numCounters];
       for (int i = 0; i < numCounters; ++i)
-        rms_per_proc[i] = sqrt( sum_sq[i] / comm->nprocs );
+        rms_per_proc[i] = Kokkos::Experimental::sqrt( sum_sq[i] / comm->nprocs );
 
       sprintf(smesg, "         RMS per Proc : %-12.5g | %-12.5g | %-12.5g | %-12.5g", rms_per_proc[0], rms_per_proc[1], rms_per_proc[2], rms_per_proc[AtomSum]);
       print_mesg(smesg);
@@ -1950,8 +1950,8 @@ void FixRxKokkos<DeviceType>::operator()(Tag_FixRxKokkos_firstPairOperator<WT_FL
 
     if (rsq < cutsq_ij)
     {
-      const double rcut = sqrt( cutsq_ij );
-      double rij = sqrt(rsq);
+      const double rcut = Kokkos::Experimental::sqrt( cutsq_ij );
+      double rij = Kokkos::Experimental::sqrt(rsq);
       double ratio = rij/rcut;
 
       double wij = 0.0;
@@ -2126,8 +2126,8 @@ void FixRxKokkos<DeviceType>::computeLocalTemperature()
 
             if (rsq < cutsq_ij)
             {
-              const double rcut = sqrt( cutsq_ij );
-              double rij = sqrt(rsq);
+              const double rcut = Kokkos::Experimental::sqrt( cutsq_ij );
+              double rij = Kokkos::Experimental::sqrt(rsq);
               double ratio = rij/rcut;
 
               double wij = 0.0;

--- a/src/KOKKOS/fix_shake_kokkos.cpp
+++ b/src/KOKKOS/fix_shake_kokkos.cpp
@@ -640,10 +640,10 @@ void FixShakeKokkos<DeviceType>::shake(int m, EV_FLOAT& ev) const
   // exact quadratic solution for lamda
 
   double lamda,lamda1,lamda2;
-  lamda1 = (-b+sqrt(determ)) / (2.0*a);
-  lamda2 = (-b-sqrt(determ)) / (2.0*a);
+  lamda1 = (-b+Kokkos::Experimental::sqrt(determ)) / (2.0*a);
+  lamda2 = (-b-Kokkos::Experimental::sqrt(determ)) / (2.0*a);
 
-  if (fabs(lamda1) <= fabs(lamda2)) lamda = lamda1;
+  if (Kokkos::Experimental::fabs(lamda1) <= Kokkos::Experimental::fabs(lamda2)) lamda = lamda1;
   else lamda = lamda2;
 
   // update forces if atom is owned by this processor
@@ -807,8 +807,8 @@ void FixShakeKokkos<DeviceType>::shake3(int m, EV_FLOAT& ev) const
     lamda02_new = a21inv*b1 + a22inv*b2;
 
     done = 1;
-    if (fabs(lamda01_new-lamda01) > tolerance) done = 0;
-    if (fabs(lamda02_new-lamda02) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda01_new-lamda01) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda02_new-lamda02) > tolerance) done = 0;
 
     lamda01 = lamda01_new;
     lamda02 = lamda02_new;
@@ -816,7 +816,7 @@ void FixShakeKokkos<DeviceType>::shake3(int m, EV_FLOAT& ev) const
     // stop iterations before we have a floating point overflow
     // max double is < 1.0e308, so 1e150 is a reasonable cutoff
 
-    if (fabs(lamda01) > 1e150 || fabs(lamda02) > 1e150) done = 1;
+    if (Kokkos::Experimental::fabs(lamda01) > 1e150 || Kokkos::Experimental::fabs(lamda02) > 1e150) done = 1;
 
     niter++;
   }
@@ -1058,9 +1058,9 @@ void FixShakeKokkos<DeviceType>::shake4(int m, EV_FLOAT& ev) const
     lamda03_new = a31inv*b1 + a32inv*b2 + a33inv*b3;
 
     done = 1;
-    if (fabs(lamda01_new-lamda01) > tolerance) done = 0;
-    if (fabs(lamda02_new-lamda02) > tolerance) done = 0;
-    if (fabs(lamda03_new-lamda03) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda01_new-lamda01) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda02_new-lamda02) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda03_new-lamda03) > tolerance) done = 0;
 
     lamda01 = lamda01_new;
     lamda02 = lamda02_new;
@@ -1069,8 +1069,8 @@ void FixShakeKokkos<DeviceType>::shake4(int m, EV_FLOAT& ev) const
     // stop iterations before we have a floating point overflow
     // max double is < 1.0e308, so 1e150 is a reasonable cutoff
 
-    if (fabs(lamda01) > 1e150 || fabs(lamda02) > 1e150
-        || fabs(lamda03) > 1e150) done = 1;
+    if (Kokkos::Experimental::fabs(lamda01) > 1e150 || Kokkos::Experimental::fabs(lamda02) > 1e150
+        || Kokkos::Experimental::fabs(lamda03) > 1e150) done = 1;
 
     niter++;
   }
@@ -1318,9 +1318,9 @@ void FixShakeKokkos<DeviceType>::shake3angle(int m, EV_FLOAT& ev) const
     lamda12_new = a31inv*b1 + a32inv*b2 + a33inv*b3;
 
     done = 1;
-    if (fabs(lamda01_new-lamda01) > tolerance) done = 0;
-    if (fabs(lamda02_new-lamda02) > tolerance) done = 0;
-    if (fabs(lamda12_new-lamda12) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda01_new-lamda01) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda02_new-lamda02) > tolerance) done = 0;
+    if (Kokkos::Experimental::fabs(lamda12_new-lamda12) > tolerance) done = 0;
 
     lamda01 = lamda01_new;
     lamda02 = lamda02_new;
@@ -1329,8 +1329,8 @@ void FixShakeKokkos<DeviceType>::shake3angle(int m, EV_FLOAT& ev) const
     // stop iterations before we have a floating point overflow
     // max double is < 1.0e308, so 1e150 is a reasonable cutoff
 
-    if (fabs(lamda01) > 1e150 || fabs(lamda02) > 1e150
-        || fabs(lamda12) > 1e150) done = 1;
+    if (Kokkos::Experimental::fabs(lamda01) > 1e150 || Kokkos::Experimental::fabs(lamda02) > 1e150
+        || Kokkos::Experimental::fabs(lamda12) > 1e150) done = 1;
 
     niter++;
   }
@@ -1784,19 +1784,19 @@ void FixShakeKokkos<DeviceType>::minimum_image(double *delta) const
 {
   if (triclinic == 0) {
     if (xperiodic) {
-      while (fabs(delta[0]) > xprd_half) {
+      while (Kokkos::Experimental::fabs(delta[0]) > xprd_half) {
         if (delta[0] < 0.0) delta[0] += xprd;
         else delta[0] -= xprd;
       }
     }
     if (yperiodic) {
-      while (fabs(delta[1]) > yprd_half) {
+      while (Kokkos::Experimental::fabs(delta[1]) > yprd_half) {
         if (delta[1] < 0.0) delta[1] += yprd;
         else delta[1] -= yprd;
       }
     }
     if (zperiodic) {
-      while (fabs(delta[2]) > zprd_half) {
+      while (Kokkos::Experimental::fabs(delta[2]) > zprd_half) {
         if (delta[2] < 0.0) delta[2] += zprd;
         else delta[2] -= zprd;
       }
@@ -1804,7 +1804,7 @@ void FixShakeKokkos<DeviceType>::minimum_image(double *delta) const
 
   } else {
     if (zperiodic) {
-      while (fabs(delta[2]) > zprd_half) {
+      while (Kokkos::Experimental::fabs(delta[2]) > zprd_half) {
         if (delta[2] < 0.0) {
           delta[2] += zprd;
           delta[1] += yz;
@@ -1817,7 +1817,7 @@ void FixShakeKokkos<DeviceType>::minimum_image(double *delta) const
       }
     }
     if (yperiodic) {
-      while (fabs(delta[1]) > yprd_half) {
+      while (Kokkos::Experimental::fabs(delta[1]) > yprd_half) {
         if (delta[1] < 0.0) {
           delta[1] += yprd;
           delta[0] += xy;
@@ -1828,7 +1828,7 @@ void FixShakeKokkos<DeviceType>::minimum_image(double *delta) const
       }
     }
     if (xperiodic) {
-      while (fabs(delta[0]) > xprd_half) {
+      while (Kokkos::Experimental::fabs(delta[0]) > xprd_half) {
         if (delta[0] < 0.0) delta[0] += xprd;
         else delta[0] -= xprd;
       }
@@ -1851,19 +1851,19 @@ void FixShakeKokkos<DeviceType>::minimum_image_once(double *delta) const
 {
   if (triclinic == 0) {
     if (xperiodic) {
-      if (fabs(delta[0]) > xprd_half) {
+      if (Kokkos::Experimental::fabs(delta[0]) > xprd_half) {
         if (delta[0] < 0.0) delta[0] += xprd;
         else delta[0] -= xprd;
       }
     }
     if (yperiodic) {
-      if (fabs(delta[1]) > yprd_half) {
+      if (Kokkos::Experimental::fabs(delta[1]) > yprd_half) {
         if (delta[1] < 0.0) delta[1] += yprd;
         else delta[1] -= yprd;
       }
     }
     if (zperiodic) {
-      if (fabs(delta[2]) > zprd_half) {
+      if (Kokkos::Experimental::fabs(delta[2]) > zprd_half) {
         if (delta[2] < 0.0) delta[2] += zprd;
         else delta[2] -= zprd;
       }
@@ -1871,7 +1871,7 @@ void FixShakeKokkos<DeviceType>::minimum_image_once(double *delta) const
 
   } else {
     if (zperiodic) {
-      if (fabs(delta[2]) > zprd_half) {
+      if (Kokkos::Experimental::fabs(delta[2]) > zprd_half) {
         if (delta[2] < 0.0) {
           delta[2] += zprd;
           delta[1] += yz;
@@ -1884,7 +1884,7 @@ void FixShakeKokkos<DeviceType>::minimum_image_once(double *delta) const
       }
     }
     if (yperiodic) {
-      if (fabs(delta[1]) > yprd_half) {
+      if (Kokkos::Experimental::fabs(delta[1]) > yprd_half) {
         if (delta[1] < 0.0) {
           delta[1] += yprd;
           delta[0] += xy;
@@ -1895,7 +1895,7 @@ void FixShakeKokkos<DeviceType>::minimum_image_once(double *delta) const
       }
     }
     if (xperiodic) {
-      if (fabs(delta[0]) > xprd_half) {
+      if (Kokkos::Experimental::fabs(delta[0]) > xprd_half) {
         if (delta[0] < 0.0) delta[0] += xprd;
         else delta[0] -= xprd;
       }

--- a/src/KOKKOS/fix_shardlow_kokkos.cpp
+++ b/src/KOKKOS/fix_shardlow_kokkos.cpp
@@ -306,7 +306,7 @@ void FixShardlowKokkos<DeviceType>::ssa_update_dpd(
         else Kokkos::atomic_increment(&(d_counters(1, 1)));
         Kokkos::atomic_increment(&(d_counters(1, 2)));
 #endif
-        double r = sqrt(rsq);
+        double r = Kokkos::Experimental::sqrt(rsq);
         double rinv = 1.0/r;
         double delx_rinv = delx*rinv;
         double dely_rinv = dely*rinv;
@@ -452,7 +452,7 @@ void FixShardlowKokkos<DeviceType>::ssa_update_dpde(
         Kokkos::atomic_increment(&(d_counters(1, 2)));
 #endif
 
-        double r = sqrt(rsq);
+        double r = Kokkos::Experimental::sqrt(rsq);
         double rinv = 1.0/r;
         double delx_rinv = delx*rinv;
         double dely_rinv = dely*rinv;
@@ -566,7 +566,7 @@ void FixShardlowKokkos<DeviceType>::initial_integrate(int /*vflag*/)
 
   copymode = 1;
 
-  dtsqrt = sqrt(update->dt);
+  dtsqrt = Kokkos::Experimental::sqrt(update->dt);
 
   NPairSSAKokkos<DeviceType> *np_ssa = dynamic_cast<NPairSSAKokkos<DeviceType>*>(list->np);
   if (!np_ssa) error->one(FLERR, "NPair wasn't a NPairSSAKokkos object");

--- a/src/KOKKOS/fix_shardlow_kokkos.h
+++ b/src/KOKKOS/fix_shardlow_kokkos.h
@@ -120,7 +120,7 @@ class FixShardlowKokkos : public FixShardlow {
   typedef Kokkos::View<random_external_state::es_RNG_t*,DeviceType> es_RNGs_type;
   es_RNGs_type d_rand_state;
 
-  double dtsqrt; // = sqrt(update->dt);
+  double dtsqrt; // = Kokkos::Experimental::sqrt(update->dt);
   int ghostmax;
   int nlocal, nghost;
 

--- a/src/KOKKOS/improper_class2_kokkos.cpp
+++ b/src/KOKKOS/improper_class2_kokkos.cpp
@@ -250,7 +250,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
 
     for (i = 0; i < 3; i++) {
       rmag2[i] = delr[i][0]*delr[i][0] + delr[i][1]*delr[i][1] + delr[i][2]*delr[i][2];
-      rmag[i] = sqrt(rmag2[i]);
+      rmag[i] = Kokkos::Experimental::sqrt(rmag2[i]);
       rinvmag[i] = 1.0/rmag[i];
     }
 
@@ -273,7 +273,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
     if (s2 < SMALL) s2 = SMALL;
     s2 = 1.0 / s2;
 
-    F_FLOAT s12 = sqrt(s1*s2);
+    F_FLOAT s12 = Kokkos::Experimental::sqrt(s1*s2);
     F_FLOAT c = (costheta[1]*costheta[2] + costheta[0]) * s12;
 
     // error check
@@ -288,15 +288,15 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
     if (c > 1.0) c = 1.0;
     if (c < -1.0) c = -1.0;
 
-    F_FLOAT s = sqrt(1.0 - c*c);
+    F_FLOAT s = Kokkos::Experimental::sqrt(1.0 - c*c);
     if (s < SMALL) s = SMALL;
 
     for (i = 0; i < 3; i++) {
       if (costheta[i] > 1.0)  costheta[i] = 1.0;
       if (costheta[i] < -1.0) costheta[i] = -1.0;
-      theta[i] = acos(costheta[i]);
+      theta[i] = Kokkos::Experimental::acos(costheta[i]);
       cossqtheta[i] = costheta[i]*costheta[i];
-      sintheta[i] = sin(theta[i]);
+      sintheta[i] = Kokkos::Experimental::sin(theta[i]);
       invstheta[i] = 1.0/sintheta[i];
       sinsqtheta[i] = sintheta[i]*sintheta[i];
     }
@@ -336,11 +336,11 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
     // chi ABCD, CBDA, DBAC: final chi is average of three
 
     schiABCD = dotCBDBAB * invs3r[0];
-    chiABCD = asin(schiABCD);
+    chiABCD = Kokkos::Experimental::asin(schiABCD);
     schiCBDA = dotDBABCB * invs3r[1];
-    chiCBDA = asin(schiCBDA);
+    chiCBDA = Kokkos::Experimental::asin(schiCBDA);
     schiDBAC = dotABCBDB * invs3r[2];
-    chiDBAC = asin(schiDBAC);
+    chiDBAC = Kokkos::Experimental::asin(schiDBAC);
 
     chi = (chiABCD + chiCBDA + chiDBAC) / 3.0;
     deltachi = chi - d_chi0[type];
@@ -385,7 +385,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
 
     tt1 = costheta[0] / rmag2[0];
     tt3 = costheta[0] / rmag2[1];
-    sc1 = 1.0 / sqrt(1.0 - cossqtheta[0]);
+    sc1 = 1.0 / Kokkos::Experimental::sqrt(1.0 - cossqtheta[0]);
 
     dthetadr[0][0][0] = sc1 * ((tt1 * delr[0][0]) -
                                (delr[1][0] * rinvmag[0] * rinvmag[1]));
@@ -417,7 +417,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
 
     tt1 = costheta[1] / rmag2[1];
     tt3 = costheta[1] / rmag2[2];
-    sc1 = 1.0 / sqrt(1.0 - cossqtheta[1]);
+    sc1 = 1.0 / Kokkos::Experimental::sqrt(1.0 - cossqtheta[1]);
 
     dthetadr[1][2][0] = sc1 * ((tt1 * delr[1][0]) -
                                (delr[2][0] * rinvmag[1] * rinvmag[2]));
@@ -448,7 +448,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
 
     tt1 = costheta[2] / rmag2[0];
     tt3 = costheta[2] / rmag2[2];
-    sc1 = 1.0 / sqrt(1.0 - cossqtheta[2]);
+    sc1 = 1.0 / Kokkos::Experimental::sqrt(1.0 - cossqtheta[2]);
 
     dthetadr[2][0][0] = sc1 * ((tt1 * delr[0][0]) -
                                (delr[2][0] * rinvmag[0] * rinvmag[2]));
@@ -475,7 +475,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
     dthetadr[2][3][2] = sc1 * ((tt3 * delr[2][2]) -
                                (delr[0][2] * rinvmag[2] * rinvmag[0]));
 
-    // compute d( 1 / sin(theta))/dr
+    // compute d( 1 / Kokkos::Experimental::sin(theta))/dr
     // i = angle, j = atom, k = direction
 
     for (i = 0; i < 3; i++) {
@@ -485,7 +485,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
           dinvsth[i][j][k] = cossin2 * dthetadr[i][j][k];
     }
 
-    // compute d(1 / sin(theta) * |r_AB| * |r_CB| * |r_DB|)/dr
+    // compute d(1 / Kokkos::Experimental::sin(theta) * |r_AB| * |r_CB| * |r_DB|)/dr
     // i = angle, j = atom
 
     for (i = 0; i < 4; i++)
@@ -589,11 +589,11 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2Compute<NEWTO
     for (i = 0; i < 4; i++)
       for (j = 0; j < 3; j++) {
         ftmp = (fdot[0][i][j] * invs3r[0]) + (dinvs3r[0][i][j] * dotCBDBAB);
-        dchi[0][i][j] = ftmp / cos(chiABCD);
+        dchi[0][i][j] = ftmp / Kokkos::Experimental::cos(chiABCD);
         ftmp = (fdot[1][i][j] * invs3r[1]) + (dinvs3r[1][i][j] * dotDBABCB);
-        dchi[1][i][j] = ftmp / cos(chiCBDA);
+        dchi[1][i][j] = ftmp / Kokkos::Experimental::cos(chiCBDA);
         ftmp = (fdot[2][i][j] * invs3r[2]) + (dinvs3r[2][i][j] * dotABCBDB);
-        dchi[2][i][j] = ftmp / cos(chiDBAC);
+        dchi[2][i][j] = ftmp / Kokkos::Experimental::cos(chiDBAC);
         dtotalchi[i][j] = (dchi[0][i][j]+dchi[1][i][j]+dchi[2][i][j]) / 3.0;
       }
 
@@ -700,28 +700,28 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2AngleAngle<NE
     // bond lengths
 
     rABmag2 = delxAB*delxAB + delyAB*delyAB + delzAB*delzAB;
-    rAB = sqrt(rABmag2);
+    rAB = Kokkos::Experimental::sqrt(rABmag2);
     rBCmag2 = delxBC*delxBC + delyBC*delyBC + delzBC*delzBC;
-    rBC = sqrt(rBCmag2);
+    rBC = Kokkos::Experimental::sqrt(rBCmag2);
     rBDmag2 = delxBD*delxBD + delyBD*delyBD + delzBD*delzBD;
-    rBD = sqrt(rBDmag2);
+    rBD = Kokkos::Experimental::sqrt(rBDmag2);
 
     // angle ABC, ABD, CBD
 
     costhABC = (delxAB*delxBC + delyAB*delyBC + delzAB*delzBC) / (rAB * rBC);
     if (costhABC > 1.0)  costhABC = 1.0;
     if (costhABC < -1.0) costhABC = -1.0;
-    thetaABC = acos(costhABC);
+    thetaABC = Kokkos::Experimental::acos(costhABC);
 
     costhABD = (delxAB*delxBD + delyAB*delyBD + delzAB*delzBD) / (rAB * rBD);
     if (costhABD > 1.0)  costhABD = 1.0;
     if (costhABD < -1.0) costhABD = -1.0;
-    thetaABD = acos(costhABD);
+    thetaABD = Kokkos::Experimental::acos(costhABD);
 
     costhCBD = (delxBC*delxBD + delyBC*delyBD + delzBC*delzBD) /(rBC * rBD);
     if (costhCBD > 1.0)  costhCBD = 1.0;
     if (costhCBD < -1.0) costhCBD = -1.0;
-    thetaCBD = acos(costhCBD);
+    thetaCBD = Kokkos::Experimental::acos(costhCBD);
 
     dthABC = thetaABC - d_aa_theta0_1[type];
     dthABD = thetaABD - d_aa_theta0_2[type];
@@ -742,7 +742,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2AngleAngle<NE
 
     // angle ABC
 
-    sc1 = sqrt(1.0/(1.0 - costhABC*costhABC));
+    sc1 = Kokkos::Experimental::sqrt(1.0/(1.0 - costhABC*costhABC));
     t1 = costhABC / rABmag2;
     t3 = costhABC / rBCmag2;
     r12 = 1.0 / (rAB * rBC);
@@ -762,7 +762,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2AngleAngle<NE
 
     // angle CBD
 
-    sc1 = sqrt(1.0/(1.0 - costhCBD*costhCBD));
+    sc1 = Kokkos::Experimental::sqrt(1.0/(1.0 - costhCBD*costhCBD));
     t1 = costhCBD / rBCmag2;
     t3 = costhCBD / rBDmag2;
     r12 = 1.0 / (rBC * rBD);
@@ -782,7 +782,7 @@ void ImproperClass2Kokkos<DeviceType>::operator()(TagImproperClass2AngleAngle<NE
 
     // angle ABD
 
-    sc1 = sqrt(1.0/(1.0 - costhABD*costhABD));
+    sc1 = Kokkos::Experimental::sqrt(1.0/(1.0 - costhABD*costhABD));
     t1 = costhABD / rABmag2;
     t3 = costhABD / rBDmag2;
     r12 = 1.0 / (rAB * rBD);

--- a/src/KOKKOS/improper_harmonic_kokkos.cpp
+++ b/src/KOKKOS/improper_harmonic_kokkos.cpp
@@ -184,9 +184,9 @@ void ImproperHarmonicKokkos<DeviceType>::operator()(TagImproperHarmonicCompute<N
   const F_FLOAT ss2 = 1.0 / (vb2x*vb2x + vb2y*vb2y + vb2z*vb2z);
   const F_FLOAT ss3 = 1.0 / (vb3x*vb3x + vb3y*vb3y + vb3z*vb3z);
 
-  const F_FLOAT r1 = sqrt(ss1);
-  const F_FLOAT r2 = sqrt(ss2);
-  const F_FLOAT r3 = sqrt(ss3);
+  const F_FLOAT r1 = Kokkos::Experimental::sqrt(ss1);
+  const F_FLOAT r2 = Kokkos::Experimental::sqrt(ss2);
+  const F_FLOAT r3 = Kokkos::Experimental::sqrt(ss3);
 
   // sin and cos of improper
 
@@ -202,7 +202,7 @@ void ImproperHarmonicKokkos<DeviceType>::operator()(TagImproperHarmonicCompute<N
   if (s2 < SMALL) s2 = SMALL;
   s2 = 1.0 / s2;
 
-  F_FLOAT s12 = sqrt(s1*s2);
+  F_FLOAT s12 = Kokkos::Experimental::sqrt(s1*s2);
   F_FLOAT c = (c1*c2 + c0) * s12;
 
   // error check
@@ -213,12 +213,12 @@ void ImproperHarmonicKokkos<DeviceType>::operator()(TagImproperHarmonicCompute<N
   if (c > 1.0) c = 1.0;
   if (c < -1.0) c = -1.0;
 
-  F_FLOAT s = sqrt(1.0 - c*c);
+  F_FLOAT s = Kokkos::Experimental::sqrt(1.0 - c*c);
   if (s < SMALL) s = SMALL;
 
   // force & energy
 
-  const F_FLOAT domega = acos(c) - d_chi[type];
+  const F_FLOAT domega = Kokkos::Experimental::acos(c) - d_chi[type];
   F_FLOAT a = d_k[type] * domega;
 
   F_FLOAT eimproper = 0.0;

--- a/src/KOKKOS/kissfft_kokkos.h
+++ b/src/KOKKOS/kissfft_kokkos.h
@@ -119,11 +119,11 @@
     }while(0)
 */
 
-#define KISS_FFT_COS(phase) (FFT_SCALAR) cos(phase)
-#define KISS_FFT_SIN(phase) (FFT_SCALAR) sin(phase)
+#define KISS_FFT_COS(phase) (FFT_SCALAR) Kokkos::Experimental::cos(phase)
+#define KISS_FFT_SIN(phase) (FFT_SCALAR) Kokkos::Experimental::sin(phase)
 #define HALF_OF(x) ((x)*.5)
 
-#define  kf_cexp(x,x_index,phase) \
+#define  kf_Kokkos::Experimental::cexp(x,x_index,phase) \
         do{ \
                 (x)(x_index).re = KISS_FFT_COS(phase);\
                 (x)(x_index).im = KISS_FFT_SIN(phase);\
@@ -456,7 +456,7 @@ class KissFFTKokkos {
   {
       int p=4, nf=0;
       double floor_sqrt;
-      floor_sqrt = floor( sqrt((double)n) );
+      floor_sqrt = floor( Kokkos::Experimental::sqrt((double)n) );
       int facbuf_count = 0;
       int p_max = 0;
 
@@ -505,7 +505,7 @@ class KissFFTKokkos {
 
           for (i=0;i<nfft;++i) {
               const double phase = (st.inverse ? 2.0*M_PI:-2.0*M_PI)*i / nfft;
-              kf_cexp(k_twiddles.h_view,i,phase );
+              kf_Kokkos::Experimental::cexp(k_twiddles.h_view,i,phase );
           }
 
           int p_max = kf_factor(nfft,k_factors.h_view);

--- a/src/KOKKOS/math_special_kokkos.h
+++ b/src/KOKKOS/math_special_kokkos.h
@@ -29,15 +29,15 @@ namespace MathSpecialKokkos {
   // fast 2**x function without argument checks for little endian CPUs
   extern double exp2_x86(double x);
 
-  // scaled error function complement exp(x*x)*erfc(x) for coul/long styles
+  // scaled error function complement Kokkos::Experimental::exp(x*x)*erfc(x) for coul/long styles
 
   static inline double my_erfcx(const double x)
   {
     if (x >= 0.0) return erfcx_y100(400.0/(4.0+x));
-    else return 2.0*exp(x*x) - erfcx_y100(400.0/(4.0-x));
+    else return 2.0*Kokkos::Experimental::exp(x*x) - erfcx_y100(400.0/(4.0-x));
   }
 
-  // exp(-x*x) for coul/long styles
+  // Kokkos::Experimental::exp(-x*x) for coul/long styles
 
   static inline double expmsq(double x)
   {
@@ -50,20 +50,20 @@ namespace MathSpecialKokkos {
 #endif
   }
 
-  // x**2, use instead of pow(x,2.0)
+  // x**2, use instead of Kokkos::Experimental::pow(x,2.0)
   KOKKOS_INLINE_FUNCTION
   static double square(const double &x) { return x*x; }
 
-  // x**3, use instead of pow(x,3.0)
+  // x**3, use instead of Kokkos::Experimental::pow(x,3.0)
   KOKKOS_INLINE_FUNCTION
   static double cube(const double &x) { return x*x*x; }
 
-  // return -1.0 for odd n, 1.0 for even n, like pow(-1.0,n)
+  // return -1.0 for odd n, 1.0 for even n, like Kokkos::Experimental::pow(-1.0,n)
   KOKKOS_INLINE_FUNCTION
   static double powsign(const int n) { return (n & 1) ? -1.0 : 1.0; }
 
-  // optimized version of pow(x,n) with n being integer
-  // up to 10x faster than pow(x,y)
+  // optimized version of Kokkos::Experimental::pow(x,n) with n being integer
+  // up to 10x faster than Kokkos::Experimental::pow(x,y)
 
   KOKKOS_INLINE_FUNCTION
   static double powint(const double &x, const int n) {
@@ -79,7 +79,7 @@ namespace MathSpecialKokkos {
     return (n > 0) ? yy : 1.0/yy;
   }
 
-  // optimized version of (sin(x)/x)**n with n being a _positive_ integer
+  // optimized version of (Kokkos::Experimental::sin(x)/x)**n with n being a _positive_ integer
 
   KOKKOS_INLINE_FUNCTION
   static double powsinxx(const double &x, int n) {
@@ -87,7 +87,7 @@ namespace MathSpecialKokkos {
 
     if (x == 0.0) return 1.0;
 
-    ww = sin(x)/x;
+    ww = Kokkos::Experimental::sin(x)/x;
 
     for (yy = 1.0; n != 0; n >>= 1, ww *=ww)
       if (n & 1) yy *= ww;

--- a/src/KOKKOS/min_cg_kokkos.cpp
+++ b/src/KOKKOS/min_cg_kokkos.cpp
@@ -93,8 +93,8 @@ int MinCGKokkos::iterate(int maxiter)
 
     // energy tolerance criterion
 
-    if (fabs(ecurrent-eprevious) <
-        update->etol * 0.5*(fabs(ecurrent) + fabs(eprevious) + EPS_ENERGY))
+    if (Kokkos::Experimental::fabs(ecurrent-eprevious) <
+        update->etol * 0.5*(Kokkos::Experimental::fabs(ecurrent) + Kokkos::Experimental::fabs(eprevious) + EPS_ENERGY))
       return ETOL;
 
     // force tolerance criterion

--- a/src/KOKKOS/min_kokkos.cpp
+++ b/src/KOKKOS/min_kokkos.cpp
@@ -231,8 +231,8 @@ void MinKokkos::setup(int flag)
   if (output->thermo->normflag) ecurrent /= atom->natoms;
 
   einitial = ecurrent;
-  fnorm2_init = sqrt(fnorm_sqr());
-  fnorminf_init = sqrt(fnorm_inf());
+  fnorm2_init = Kokkos::Experimental::sqrt(fnorm_sqr());
+  fnorminf_init = Kokkos::Experimental::sqrt(fnorm_inf());
 }
 
 /* ----------------------------------------------------------------------
@@ -337,8 +337,8 @@ void MinKokkos::setup_minimal(int flag)
   if (output->thermo->normflag) ecurrent /= atom->natoms;
 
   einitial = ecurrent;
-  fnorm2_init = sqrt(fnorm_sqr());
-  fnorminf_init = sqrt(fnorm_inf());
+  fnorm2_init = Kokkos::Experimental::sqrt(fnorm_sqr());
+  fnorminf_init = Kokkos::Experimental::sqrt(fnorm_inf());
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/min_linesearch_kokkos.cpp
+++ b/src/KOKKOS/min_linesearch_kokkos.cpp
@@ -218,7 +218,7 @@ int MinLineSearchKokkos::linemin_quadratic(double eoriginal, double &alpha)
     auto l_h = h;
 
     Kokkos::parallel_reduce(nvec, LAMMPS_LAMBDA(const int& i, double& hme) {
-      hme = MAX(hme,fabs(l_h[i]));
+      hme = MAX(hme,Kokkos::Experimental::fabs(l_h[i]));
     },Kokkos::Max<double>(hme));
   }
   MPI_Allreduce(&hme,&hmaxall,1,MPI_DOUBLE,MPI_MAX,world);
@@ -227,7 +227,7 @@ int MinLineSearchKokkos::linemin_quadratic(double eoriginal, double &alpha)
     double alpha_extra = modify->max_alpha(hextra);
     alphamax = MIN(alphamax,alpha_extra);
     for (int i = 0; i < nextra_global; i++)
-      hmaxall = MAX(hmaxall,fabs(hextra[i]));
+      hmaxall = MAX(hmaxall,Kokkos::Experimental::fabs(hextra[i]));
   }
 
   if (hmaxall == 0.0) return ZEROFORCE;
@@ -302,7 +302,7 @@ int MinLineSearchKokkos::linemin_quadratic(double eoriginal, double &alpha)
 
     // if fh or delfh is epsilon, reset to starting point, exit with error
 
-    if (fabs(fh) < EPS_QUAD || fabs(delfh) < EPS_QUAD) {
+    if (Kokkos::Experimental::fabs(fh) < EPS_QUAD || Kokkos::Experimental::fabs(delfh) < EPS_QUAD) {
       ecurrent = alpha_step(0.0,0);
       return ZEROQUAD;
     }
@@ -310,7 +310,7 @@ int MinLineSearchKokkos::linemin_quadratic(double eoriginal, double &alpha)
     // Check if ready for quadratic projection, equivalent to secant method
     // alpha0 = projected alpha
 
-    relerr = fabs(1.0-(0.5*(alpha-alphaprev)*(fh+fhprev)+ecurrent)/engprev);
+    relerr = Kokkos::Experimental::fabs(1.0-(0.5*(alpha-alphaprev)*(fh+fhprev)+ecurrent)/engprev);
     alpha0 = alpha - (alpha-alphaprev)*fh/delfh;
 
     if (relerr <= QUADRATIC_TOL && alpha0 > 0.0 && alpha0 < alphamax) {

--- a/src/KOKKOS/neigh_bond_kokkos.cpp
+++ b/src/KOKKOS/neigh_bond_kokkos.cpp
@@ -1163,19 +1163,19 @@ void NeighBondKokkos<DeviceType>::minimum_image(X_FLOAT &dx, X_FLOAT &dy, X_FLOA
 {
   if (triclinic == 0) {
     if (xperiodic) {
-      if (fabs(dx) > xprd_half) {
+      if (Kokkos::Experimental::fabs(dx) > xprd_half) {
         if (dx < 0.0) dx += xprd;
         else dx -= xprd;
       }
     }
     if (yperiodic) {
-      if (fabs(dy) > yprd_half) {
+      if (Kokkos::Experimental::fabs(dy) > yprd_half) {
         if (dy < 0.0) dy += yprd;
         else dy -= yprd;
       }
     }
     if (zperiodic) {
-      if (fabs(dz) > zprd_half) {
+      if (Kokkos::Experimental::fabs(dz) > zprd_half) {
         if (dz < 0.0) dz += zprd;
         else dz -= zprd;
       }
@@ -1183,7 +1183,7 @@ void NeighBondKokkos<DeviceType>::minimum_image(X_FLOAT &dx, X_FLOAT &dy, X_FLOA
 
   } else {
     if (zperiodic) {
-      if (fabs(dz) > zprd_half) {
+      if (Kokkos::Experimental::fabs(dz) > zprd_half) {
         if (dz < 0.0) {
           dz += zprd;
           dy += yz;
@@ -1196,7 +1196,7 @@ void NeighBondKokkos<DeviceType>::minimum_image(X_FLOAT &dx, X_FLOAT &dy, X_FLOA
       }
     }
     if (yperiodic) {
-      if (fabs(dy) > yprd_half) {
+      if (Kokkos::Experimental::fabs(dy) > yprd_half) {
         if (dy < 0.0) {
           dy += yprd;
           dx += xy;
@@ -1207,7 +1207,7 @@ void NeighBondKokkos<DeviceType>::minimum_image(X_FLOAT &dx, X_FLOAT &dy, X_FLOA
       }
     }
     if (xperiodic) {
-      if (fabs(dx) > xprd_half) {
+      if (Kokkos::Experimental::fabs(dx) > xprd_half) {
         if (dx < 0.0) dx += xprd;
         else dx -= xprd;
       }

--- a/src/KOKKOS/neighbor_kokkos.cpp
+++ b/src/KOKKOS/neighbor_kokkos.cpp
@@ -173,11 +173,11 @@ int NeighborKokkos::check_distance_kokkos()
       delx = bboxlo[0] - boxlo_hold[0];
       dely = bboxlo[1] - boxlo_hold[1];
       delz = bboxlo[2] - boxlo_hold[2];
-      delta1 = sqrt(delx*delx + dely*dely + delz*delz);
+      delta1 = Kokkos::Experimental::sqrt(delx*delx + dely*dely + delz*delz);
       delx = bboxhi[0] - boxhi_hold[0];
       dely = bboxhi[1] - boxhi_hold[1];
       delz = bboxhi[2] - boxhi_hold[2];
-      delta2 = sqrt(delx*delx + dely*dely + delz*delz);
+      delta2 = Kokkos::Experimental::sqrt(delx*delx + dely*dely + delz*delz);
       delta = 0.5 * (skin - (delta1+delta2));
       deltasq = delta*delta;
     } else {
@@ -187,7 +187,7 @@ int NeighborKokkos::check_distance_kokkos()
         delx = corners[i][0] - corners_hold[i][0];
         dely = corners[i][1] - corners_hold[i][1];
         delz = corners[i][2] - corners_hold[i][2];
-        delta = sqrt(delx*delx + dely*dely + delz*delz);
+        delta = Kokkos::Experimental::sqrt(delx*delx + dely*dely + delz*delz);
         if (delta > delta1) delta1 = delta;
         else if (delta > delta2) delta2 = delta;
       }

--- a/src/KOKKOS/npair_kokkos.h
+++ b/src/KOKKOS/npair_kokkos.h
@@ -367,9 +367,9 @@ class NeighborKokkosExecute
 
   KOKKOS_INLINE_FUNCTION
   int minimum_image_check(double dx, double dy, double dz) const {
-    if (xperiodic && fabs(dx) > xprd_half) return 1;
-    if (yperiodic && fabs(dy) > yprd_half) return 1;
-    if (zperiodic && fabs(dz) > zprd_half) return 1;
+    if (xperiodic && Kokkos::Experimental::fabs(dx) > xprd_half) return 1;
+    if (yperiodic && Kokkos::Experimental::fabs(dy) > yprd_half) return 1;
+    if (zperiodic && Kokkos::Experimental::fabs(dz) > zprd_half) return 1;
     return 0;
   }
 

--- a/src/KOKKOS/npair_ssa_kokkos.h
+++ b/src/KOKKOS/npair_ssa_kokkos.h
@@ -342,9 +342,9 @@ class NPairSSAKokkosExecute
 
   KOKKOS_INLINE_FUNCTION
   int minimum_image_check(double dx, double dy, double dz) const {
-    if (xperiodic && fabs(dx) > xprd_half) return 1;
-    if (yperiodic && fabs(dy) > yprd_half) return 1;
-    if (zperiodic && fabs(dz) > zprd_half) return 1;
+    if (xperiodic && Kokkos::Experimental::fabs(dx) > xprd_half) return 1;
+    if (yperiodic && Kokkos::Experimental::fabs(dy) > yprd_half) return 1;
+    if (zperiodic && Kokkos::Experimental::fabs(dz) > zprd_half) return 1;
     return 0;
   }
 

--- a/src/KOKKOS/pair_buck_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_buck_coul_cut_kokkos.cpp
@@ -165,8 +165,8 @@ compute_fpair(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
               const int& itype, const int& jtype) const {
   const F_FLOAT r2inv = 1.0/rsq;
   const F_FLOAT r6inv = r2inv*r2inv*r2inv;
-  const F_FLOAT r = sqrt(rsq);
-  const F_FLOAT rexp = exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
+  const F_FLOAT rexp = Kokkos::Experimental::exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
 
   const F_FLOAT forcebuck =
      (STACKPARAMS?m_params[itype][jtype].buck1:params(itype,jtype).buck1)*r*rexp -
@@ -186,8 +186,8 @@ compute_evdwl(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
               const int& itype, const int& jtype) const {
   const F_FLOAT r2inv = 1.0/rsq;
   const F_FLOAT r6inv = r2inv*r2inv*r2inv;
-  const F_FLOAT r = sqrt(rsq);
-  const F_FLOAT rexp = exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
+  const F_FLOAT rexp = Kokkos::Experimental::exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
 
   return (STACKPARAMS?m_params[itype][jtype].a:params(itype,jtype).a)*rexp -
                 (STACKPARAMS?m_params[itype][jtype].c:params(itype,jtype).c)*r6inv -
@@ -204,7 +204,7 @@ F_FLOAT PairBuckCoulCutKokkos<DeviceType>::
 compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT forcecoul;
 
   forcecoul = qqrd2e*qtmp*q(j) *rinv;
@@ -222,7 +222,7 @@ F_FLOAT PairBuckCoulCutKokkos<DeviceType>::
 compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int& j,
               const int& /*itype*/, const int& /*jtype*/, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
 
   return factor_coul*qqrd2e*qtmp*q(j)*rinv;
 

--- a/src/KOKKOS/pair_buck_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_buck_coul_long_kokkos.cpp
@@ -166,8 +166,8 @@ compute_fpair(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
               const int& itype, const int& jtype) const {
   const F_FLOAT r2inv = 1.0/rsq;
   const F_FLOAT r6inv = r2inv*r2inv*r2inv;
-  const F_FLOAT r = sqrt(rsq);
-  const F_FLOAT rexp = exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
+  const F_FLOAT rexp = Kokkos::Experimental::exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
 
   const F_FLOAT forcebuck =
      (STACKPARAMS?m_params[itype][jtype].buck1:params(itype,jtype).buck1)*r*rexp -
@@ -187,8 +187,8 @@ compute_evdwl(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
               const int& itype, const int& jtype) const {
   const F_FLOAT r2inv = 1.0/rsq;
   const F_FLOAT r6inv = r2inv*r2inv*r2inv;
-  const F_FLOAT r = sqrt(rsq);
-  const F_FLOAT rexp = exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
+  const F_FLOAT rexp = Kokkos::Experimental::exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
 
   return (STACKPARAMS?m_params[itype][jtype].a:params(itype,jtype).a)*rexp -
                 (STACKPARAMS?m_params[itype][jtype].c:params(itype,jtype).c)*r6inv -
@@ -220,9 +220,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return forcecoul/rsq;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT rinv = 1.0/r;
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
@@ -259,9 +259,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return ecoul;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
     const F_FLOAT prefactor = qqrd2e * qtmp*q[j]/r;

--- a/src/KOKKOS/pair_buck_kokkos.cpp
+++ b/src/KOKKOS/pair_buck_kokkos.cpp
@@ -147,8 +147,8 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
   const F_FLOAT r6inv = r2inv*r2inv*r2inv;
-  const F_FLOAT r = sqrt(rsq);
-  const F_FLOAT rexp = exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
+  const F_FLOAT rexp = Kokkos::Experimental::exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
 
   const F_FLOAT forcebuck =
      (STACKPARAMS?m_params[itype][jtype].buck1:params(itype,jtype).buck1)*r*rexp -
@@ -166,8 +166,8 @@ compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
   const F_FLOAT r6inv = r2inv*r2inv*r2inv;
-  const F_FLOAT r = sqrt(rsq);
-  const F_FLOAT rexp = exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
+  const F_FLOAT rexp = Kokkos::Experimental::exp(-r*(STACKPARAMS?m_params[itype][jtype].rhoinv:params(itype,jtype).rhoinv));
 
 
   return (STACKPARAMS?m_params[itype][jtype].a:params(itype,jtype).a)*rexp -

--- a/src/KOKKOS/pair_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_cut_kokkos.cpp
@@ -142,7 +142,7 @@ F_FLOAT PairCoulCutKokkos<DeviceType>::
 compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j, const int& itype,
               const int& jtype, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT forcecoul;
 
   forcecoul = qqrd2e*(STACKPARAMS?m_params[itype][jtype].scale:params(itype,jtype).scale)*
@@ -158,7 +158,7 @@ F_FLOAT PairCoulCutKokkos<DeviceType>::
 compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j, const int& itype,
               const int& jtype, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
 
   return factor_coul*qqrd2e * (STACKPARAMS?m_params[itype][jtype].scale:params(itype,jtype).scale)
     * qtmp *q(j)*rinv;

--- a/src/KOKKOS/pair_coul_debye_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_debye_kokkos.cpp
@@ -156,9 +156,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& itype, const int& jtype, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r = 1.0/rinv;
-  const F_FLOAT screening = exp(-kappa*r);
+  const F_FLOAT screening = Kokkos::Experimental::exp(-kappa*r);
   F_FLOAT forcecoul;
 
   forcecoul = qqrd2e * qtmp * q(j) * screening * (kappa + rinv) *
@@ -179,9 +179,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& itype, const int& jtype, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r = 1.0/rinv;
-  const F_FLOAT screening = exp(-kappa*r);
+  const F_FLOAT screening = Kokkos::Experimental::exp(-kappa*r);
 
   return factor_coul * qqrd2e * qtmp * q(j) * rinv * screening *
           (STACKPARAMS?m_params[itype][jtype].scale:params(itype,jtype).scale);

--- a/src/KOKKOS/pair_coul_dsf_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_dsf_kokkos.cpp
@@ -267,9 +267,9 @@ void PairCoulDSFKokkos<DeviceType>::operator()(TagPairCoulDSFKernelA<NEIGHFLAG,N
 
 
       const F_FLOAT r2inv = 1.0/rsq;
-      const F_FLOAT r = sqrt(rsq);
+      const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
       const F_FLOAT prefactor = factor_coul * qqrd2e*qtmp*q[j]/r;
-      const F_FLOAT erfcd = exp(-alpha*alpha*rsq);
+      const F_FLOAT erfcd = Kokkos::Experimental::exp(-alpha*alpha*rsq);
       const F_FLOAT t = 1.0 / (1.0 + EWALD_P*alpha*r);
       const F_FLOAT erfcc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * erfcd;
       const F_FLOAT forcecoul = prefactor * (erfcc/r + 2.0*alpha/MY_PIS * erfcd +

--- a/src/KOKKOS/pair_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_long_kokkos.cpp
@@ -188,9 +188,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return forcecoul/rsq;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT rinv = 1.0/r;
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
@@ -227,9 +227,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return ecoul;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
     const F_FLOAT prefactor = qqrd2e * qtmp*q[j]/r;

--- a/src/KOKKOS/pair_coul_wolf_kokkos.cpp
+++ b/src/KOKKOS/pair_coul_wolf_kokkos.cpp
@@ -91,8 +91,8 @@ void PairCoulWolfKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
 
   // shifted coulombic energy
 
-  e_shift = erfc(alf*cut_coul)/cut_coul;
-  f_shift = -(e_shift+ 2.0*alf/MY_PIS * exp(-alf*alf*cut_coul*cut_coul)) /
+  e_shift = Kokkos::Experimental::erfc(alf*cut_coul)/cut_coul;
+  f_shift = -(e_shift+ 2.0*alf/MY_PIS * Kokkos::Experimental::exp(-alf*alf*cut_coul*cut_coul)) /
     cut_coul;
 
   x = atomKK->k_x.view<DeviceType>();
@@ -266,10 +266,10 @@ void PairCoulWolfKokkos<DeviceType>::operator()(TagPairCoulWolfKernelA<NEIGHFLAG
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cut_coulsq) {
-      const F_FLOAT r = sqrt(rsq);
+      const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
       const F_FLOAT prefactor = qqrd2e*qtmp*q[j]/r;
-      const F_FLOAT erfcc = erfc(alf*r);
-      const F_FLOAT erfcd = exp(-alf*alf*r*r);
+      const F_FLOAT erfcc = Kokkos::Experimental::erfc(alf*r);
+      const F_FLOAT erfcd = Kokkos::Experimental::exp(-alf*alf*r*r);
       const F_FLOAT v_sh = (erfcc - e_shift*r) * prefactor;
       const F_FLOAT dvdrr = (erfcc/rsq + 2.0*alf/MY_PIS * erfcd/r) + f_shift;
       F_FLOAT forcecoul = dvdrr*rsq*prefactor;

--- a/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
+++ b/src/KOKKOS/pair_dpd_fdt_energy_kokkos.cpp
@@ -198,7 +198,7 @@ void PairDPDfdtEnergyKokkos<DeviceType>::compute(int eflag_in, int vflag_in)
   nlocal = atom->nlocal;
   int nghost = atom->nghost;
   int newton_pair = force->newton_pair;
-  dtinvsqrt = 1.0/sqrt(update->dt);
+  dtinvsqrt = 1.0/Kokkos::Experimental::sqrt(update->dt);
 
   int inum = list->inum;
   NeighListKokkos<DeviceType>* k_list = static_cast<NeighListKokkos<DeviceType>*>(list);
@@ -421,7 +421,7 @@ void PairDPDfdtEnergyKokkos<DeviceType>::operator()(TagPairDPDfdtEnergyComputeSp
 
     double cutsq_ij = STACKPARAMS?m_cutsq[itype][jtype]:d_cutsq(itype,jtype);
     if (rsq < cutsq_ij) {
-      r = sqrt(rsq);
+      r = Kokkos::Experimental::sqrt(rsq);
       if (r < EPSILON) continue;     // r can be 0.0 in DPD systems
       rinv = 1.0/r;
       double cut_ij = STACKPARAMS?m_params[itype][jtype].cut:params(itype,jtype).cut;
@@ -519,7 +519,7 @@ void PairDPDfdtEnergyKokkos<DeviceType>::operator()(TagPairDPDfdtEnergyComputeNo
 
     double cutsq_ij = STACKPARAMS?m_cutsq[itype][jtype]:d_cutsq(itype,jtype);
     if (rsq < cutsq_ij) {
-      r = sqrt(rsq);
+      r = Kokkos::Experimental::sqrt(rsq);
       if (r < EPSILON) continue;     // r can be 0.0 in DPD systems
       rinv = 1.0/r;
       double cut_ij = STACKPARAMS?m_params[itype][jtype].cut:params(itype,jtype).cut;

--- a/src/KOKKOS/pair_eam_alloy_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_alloy_kokkos.cpp
@@ -571,7 +571,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelA<NEIGHFLAG
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      F_FLOAT p = sqrt(rsq)*rdr + 1.0;
+      F_FLOAT p = Kokkos::Experimental::sqrt(rsq)*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);
       p -= m;
@@ -662,7 +662,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelAB<EFLAG>, 
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      F_FLOAT p = sqrt(rsq)*rdr + 1.0;
+      F_FLOAT p = Kokkos::Experimental::sqrt(rsq)*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);
       p -= m;
@@ -740,7 +740,7 @@ void PairEAMAlloyKokkos<DeviceType>::operator()(TagPairEAMAlloyKernelC<NEIGHFLAG
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      const F_FLOAT r = sqrt(rsq);
+      const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
       F_FLOAT p = r*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);

--- a/src/KOKKOS/pair_eam_fs_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_fs_kokkos.cpp
@@ -571,7 +571,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelA<NEIGHFLAG,NEWTO
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      F_FLOAT p = sqrt(rsq)*rdr + 1.0;
+      F_FLOAT p = Kokkos::Experimental::sqrt(rsq)*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);
       p -= m;
@@ -662,7 +662,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelAB<EFLAG>, const 
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      F_FLOAT p = sqrt(rsq)*rdr + 1.0;
+      F_FLOAT p = Kokkos::Experimental::sqrt(rsq)*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);
       p -= m;
@@ -740,7 +740,7 @@ void PairEAMFSKokkos<DeviceType>::operator()(TagPairEAMFSKernelC<NEIGHFLAG,NEWTO
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      const F_FLOAT r = sqrt(rsq);
+      const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
       F_FLOAT p = r*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);

--- a/src/KOKKOS/pair_eam_kokkos.cpp
+++ b/src/KOKKOS/pair_eam_kokkos.cpp
@@ -569,7 +569,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelA<NEIGHFLAG,NEWTON_PA
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      F_FLOAT p = sqrt(rsq)*rdr + 1.0;
+      F_FLOAT p = Kokkos::Experimental::sqrt(rsq)*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);
       p -= m;
@@ -658,7 +658,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelAB<EFLAG>, const int 
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      F_FLOAT p = sqrt(rsq)*rdr + 1.0;
+      F_FLOAT p = Kokkos::Experimental::sqrt(rsq)*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);
       p -= m;
@@ -736,7 +736,7 @@ void PairEAMKokkos<DeviceType>::operator()(TagPairEAMKernelC<NEIGHFLAG,NEWTON_PA
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq < cutforcesq) {
-      const F_FLOAT r = sqrt(rsq);
+      const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
       F_FLOAT p = r*rdr + 1.0;
       int m = static_cast<int> (p);
       m = MIN(m,nr-1);

--- a/src/KOKKOS/pair_exp6_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_exp6_rx_kokkos.cpp
@@ -531,10 +531,10 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxCompute<NEIGHFLAG,NEW
       r2inv = 1.0/rsq;
       r6inv = r2inv*r2inv*r2inv;
 
-      r = sqrt(rsq);
+      r = Kokkos::Experimental::sqrt(rsq);
       rCut2inv = 1.0/d_cutsq(itype,jtype);
       rCut6inv = rCut2inv*rCut2inv*rCut2inv;
-      rCut = sqrt(d_cutsq(itype,jtype));
+      rCut = Kokkos::Experimental::sqrt(d_cutsq(itype,jtype));
       rCutInv = 1.0/rCut;
 
       //
@@ -563,19 +563,19 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxCompute<NEIGHFLAG,NEW
       }
 
       // A2.  Apply Lorentz-Berthelot mixing rules for the i-j pair
-      alphaOld12_ij = sqrt(alphaOld1_i*alphaOld2_j);
+      alphaOld12_ij = Kokkos::Experimental::sqrt(alphaOld1_i*alphaOld2_j);
       rmOld12_ij = 0.5*(rmOld1_i + rmOld2_j);
-      epsilonOld12_ij = sqrt(epsilonOld1_i*epsilonOld2_j);
-      alphaOld21_ij = sqrt(alphaOld2_i*alphaOld1_j);
+      epsilonOld12_ij = Kokkos::Experimental::sqrt(epsilonOld1_i*epsilonOld2_j);
+      alphaOld21_ij = Kokkos::Experimental::sqrt(alphaOld2_i*alphaOld1_j);
       rmOld21_ij = 0.5*(rmOld2_i + rmOld1_j);
-      epsilonOld21_ij = sqrt(epsilonOld2_i*epsilonOld1_j);
+      epsilonOld21_ij = Kokkos::Experimental::sqrt(epsilonOld2_i*epsilonOld1_j);
 
-      alpha12_ij = sqrt(alpha1_i*alpha2_j);
+      alpha12_ij = Kokkos::Experimental::sqrt(alpha1_i*alpha2_j);
       rm12_ij = 0.5*(rm1_i + rm2_j);
-      epsilon12_ij = sqrt(epsilon1_i*epsilon2_j);
-      alpha21_ij = sqrt(alpha2_i*alpha1_j);
+      epsilon12_ij = Kokkos::Experimental::sqrt(epsilon1_i*epsilon2_j);
+      alpha21_ij = Kokkos::Experimental::sqrt(alpha2_i*alpha1_j);
       rm21_ij = 0.5*(rm2_i + rm1_j);
-      epsilon21_ij = sqrt(epsilon2_i*epsilon1_j);
+      epsilon21_ij = Kokkos::Experimental::sqrt(epsilon2_i*epsilon1_j);
 
       evdwlOldEXP6_12 = 0.0;
       evdwlOldEXP6_21 = 0.0;
@@ -667,9 +667,9 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxCompute<NEIGHFLAG,NEW
         }
 
         if (isite1 == isite2)
-          evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12;
+          evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12;
         else
-          evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12 + sqrt(mixWtSite2old_i*mixWtSite1old_j)*evdwlOldEXP6_21;
+          evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j)*evdwlOldEXP6_21;
 
         evdwlOld *= factor_lj;
 
@@ -751,8 +751,8 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxCompute<NEIGHFLAG,NEW
       //
       // Apply Mixing Rule to get the overall force for the CG pair
       //
-      if (isite1 == isite2) fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12;
-      else fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12 + sqrt(mixWtSite2old_i*mixWtSite1old_j)*fpairOldEXP6_21;
+      if (isite1 == isite2) fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12;
+      else fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j)*fpairOldEXP6_21;
 
       fx_i += delx*fpair;
       fy_i += dely*fpair;
@@ -763,8 +763,8 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxCompute<NEIGHFLAG,NEW
         a_f(j,2) -= delz*fpair;
       }
 
-      if (isite1 == isite2) evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12;
-      else evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12 + sqrt(mixWtSite2_i*mixWtSite1_j)*evdwlEXP6_21;
+      if (isite1 == isite2) evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12;
+      else evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2_i*mixWtSite1_j)*evdwlEXP6_21;
       evdwl *= factor_lj;
 
       uCGnew_i   += 0.5*evdwl;
@@ -905,10 +905,10 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxComputeNoAtomics<NEIG
       r2inv = 1.0/rsq;
       r6inv = r2inv*r2inv*r2inv;
 
-      r = sqrt(rsq);
+      r = Kokkos::Experimental::sqrt(rsq);
       rCut2inv = 1.0/d_cutsq(itype,jtype);
       rCut6inv = rCut2inv*rCut2inv*rCut2inv;
-      rCut = sqrt(d_cutsq(itype,jtype));
+      rCut = Kokkos::Experimental::sqrt(d_cutsq(itype,jtype));
       rCutInv = 1.0/rCut;
 
       //
@@ -937,19 +937,19 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxComputeNoAtomics<NEIG
       }
 
       // A2.  Apply Lorentz-Berthelot mixing rules for the i-j pair
-      alphaOld12_ij = sqrt(alphaOld1_i*alphaOld2_j);
+      alphaOld12_ij = Kokkos::Experimental::sqrt(alphaOld1_i*alphaOld2_j);
       rmOld12_ij = 0.5*(rmOld1_i + rmOld2_j);
-      epsilonOld12_ij = sqrt(epsilonOld1_i*epsilonOld2_j);
-      alphaOld21_ij = sqrt(alphaOld2_i*alphaOld1_j);
+      epsilonOld12_ij = Kokkos::Experimental::sqrt(epsilonOld1_i*epsilonOld2_j);
+      alphaOld21_ij = Kokkos::Experimental::sqrt(alphaOld2_i*alphaOld1_j);
       rmOld21_ij = 0.5*(rmOld2_i + rmOld1_j);
-      epsilonOld21_ij = sqrt(epsilonOld2_i*epsilonOld1_j);
+      epsilonOld21_ij = Kokkos::Experimental::sqrt(epsilonOld2_i*epsilonOld1_j);
 
-      alpha12_ij = sqrt(alpha1_i*alpha2_j);
+      alpha12_ij = Kokkos::Experimental::sqrt(alpha1_i*alpha2_j);
       rm12_ij = 0.5*(rm1_i + rm2_j);
-      epsilon12_ij = sqrt(epsilon1_i*epsilon2_j);
-      alpha21_ij = sqrt(alpha2_i*alpha1_j);
+      epsilon12_ij = Kokkos::Experimental::sqrt(epsilon1_i*epsilon2_j);
+      alpha21_ij = Kokkos::Experimental::sqrt(alpha2_i*alpha1_j);
       rm21_ij = 0.5*(rm2_i + rm1_j);
-      epsilon21_ij = sqrt(epsilon2_i*epsilon1_j);
+      epsilon21_ij = Kokkos::Experimental::sqrt(epsilon2_i*epsilon1_j);
 
       evdwlOldEXP6_12 = 0.0;
       evdwlOldEXP6_21 = 0.0;
@@ -1041,9 +1041,9 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxComputeNoAtomics<NEIG
         }
 
         if (isite1 == isite2)
-          evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12;
+          evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12;
         else
-          evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12 + sqrt(mixWtSite2old_i*mixWtSite1old_j)*evdwlOldEXP6_21;
+          evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j)*evdwlOldEXP6_21;
 
         evdwlOld *= factor_lj;
 
@@ -1125,8 +1125,8 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxComputeNoAtomics<NEIG
       //
       // Apply Mixing Rule to get the overall force for the CG pair
       //
-      if (isite1 == isite2) fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12;
-      else fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12 + sqrt(mixWtSite2old_i*mixWtSite1old_j)*fpairOldEXP6_21;
+      if (isite1 == isite2) fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12;
+      else fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j)*fpairOldEXP6_21;
 
       fx_i += delx*fpair;
       fy_i += dely*fpair;
@@ -1137,8 +1137,8 @@ void PairExp6rxKokkos<DeviceType>::operator()(TagPairExp6rxComputeNoAtomics<NEIG
         t_f(tid,j,2) -= delz*fpair;
       }
 
-      if (isite1 == isite2) evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12;
-      else evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12 + sqrt(mixWtSite2_i*mixWtSite1_j)*evdwlEXP6_21;
+      if (isite1 == isite2) evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12;
+      else evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2_i*mixWtSite1_j)*evdwlEXP6_21;
       evdwl *= factor_lj;
 
       uCGnew_i += 0.5*evdwl;
@@ -1235,7 +1235,7 @@ void PairExp6rxKokkos<DeviceType>::vectorized_operator(const int &ii, EV_FLOAT& 
   const double cutsq_type11 = d_cutsq(1,1);
   const double rCut2inv_type11 = 1.0/ cutsq_type11;
   const double rCut6inv_type11 = rCut2inv_type11*rCut2inv_type11*rCut2inv_type11;
-  const double rCut_type11 = sqrt( cutsq_type11 );
+  const double rCut_type11 = Kokkos::Experimental::sqrt( cutsq_type11 );
   const double rCutInv_type11 = 1.0/rCut_type11;
 
   // Do error testing locally.
@@ -1320,10 +1320,10 @@ void PairExp6rxKokkos<DeviceType>::vectorized_operator(const int &ii, EV_FLOAT& 
         const double r2inv = 1.0/rsq;
         const double r6inv = r2inv*r2inv*r2inv;
 
-        const double r = sqrt(rsq);
+        const double r = Kokkos::Experimental::sqrt(rsq);
         const double rCut2inv = (OneType) ? rCut2inv_type11 : (1.0/ cutsq_j[jlane]);
         const double rCut6inv = (OneType) ? rCut6inv_type11 : (rCut2inv*rCut2inv*rCut2inv);
-        const double rCut =     (OneType) ? rCut_type11     : (sqrt( cutsq_j[jlane] ));
+        const double rCut =     (OneType) ? rCut_type11     : (Kokkos::Experimental::sqrt( cutsq_j[jlane] ));
         const double rCutInv =  (OneType) ? rCutInv_type11  : (1.0/rCut);
 
         //
@@ -1350,19 +1350,19 @@ void PairExp6rxKokkos<DeviceType>::vectorized_operator(const int &ii, EV_FLOAT& 
         const double mixWtSite2old_j = PairExp6ParamData.mixWtSite2old[j];
 
         // A2.  Apply Lorentz-Berthelot mixing rules for the i-j pair
-        const double alphaOld12_ij = sqrt(alphaOld1_i*alphaOld2_j);
+        const double alphaOld12_ij = Kokkos::Experimental::sqrt(alphaOld1_i*alphaOld2_j);
         const double rmOld12_ij = 0.5*(rmOld1_i + rmOld2_j);
-        const double epsilonOld12_ij = sqrt(epsilonOld1_i*epsilonOld2_j);
-        const double alphaOld21_ij = sqrt(alphaOld2_i*alphaOld1_j);
+        const double epsilonOld12_ij = Kokkos::Experimental::sqrt(epsilonOld1_i*epsilonOld2_j);
+        const double alphaOld21_ij = Kokkos::Experimental::sqrt(alphaOld2_i*alphaOld1_j);
         const double rmOld21_ij = 0.5*(rmOld2_i + rmOld1_j);
-        const double epsilonOld21_ij = sqrt(epsilonOld2_i*epsilonOld1_j);
+        const double epsilonOld21_ij = Kokkos::Experimental::sqrt(epsilonOld2_i*epsilonOld1_j);
 
-        const double alpha12_ij = sqrt(alpha1_i*alpha2_j);
+        const double alpha12_ij = Kokkos::Experimental::sqrt(alpha1_i*alpha2_j);
         const double rm12_ij = 0.5*(rm1_i + rm2_j);
-        const double epsilon12_ij = sqrt(epsilon1_i*epsilon2_j);
-        const double alpha21_ij = sqrt(alpha2_i*alpha1_j);
+        const double epsilon12_ij = Kokkos::Experimental::sqrt(epsilon1_i*epsilon2_j);
+        const double alpha21_ij = Kokkos::Experimental::sqrt(alpha2_i*alpha1_j);
         const double rm21_ij = 0.5*(rm2_i + rm1_j);
-        const double epsilon21_ij = sqrt(epsilon2_i*epsilon1_j);
+        const double epsilon21_ij = Kokkos::Experimental::sqrt(epsilon2_i*epsilon1_j);
 
         double evdwlOldEXP6_12 = 0.0;
         double evdwlOldEXP6_21 = 0.0;
@@ -1456,9 +1456,9 @@ void PairExp6rxKokkos<DeviceType>::vectorized_operator(const int &ii, EV_FLOAT& 
 
           double evdwlOld;
           if (Site1EqSite2)
-            evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12;
+            evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12;
           else
-            evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12 + sqrt(mixWtSite2old_i*mixWtSite1old_j)*evdwlOldEXP6_21;
+            evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwlOldEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j)*evdwlOldEXP6_21;
 
           evdwlOld *= factor_lj;
 
@@ -1542,15 +1542,15 @@ void PairExp6rxKokkos<DeviceType>::vectorized_operator(const int &ii, EV_FLOAT& 
         //
         double fpair;
         if (Site1EqSite2)
-          fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12;
+          fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12;
         else
-          fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12 + sqrt(mixWtSite2old_i*mixWtSite1old_j)*fpairOldEXP6_21;
+          fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpairOldEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j)*fpairOldEXP6_21;
 
         double evdwl;
         if (Site1EqSite2)
-          evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12;
+          evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12;
         else
-          evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12 + sqrt(mixWtSite2_i*mixWtSite1_j)*evdwlEXP6_21;
+          evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwlEXP6_12 + Kokkos::Experimental::sqrt(mixWtSite2_i*mixWtSite1_j)*evdwlEXP6_21;
 
         evdwl *= factor_lj;
 
@@ -1967,8 +1967,8 @@ void PairExp6rxKokkos<DeviceType>::getMixingWeights(int id,double &epsilon1,doub
 
         rmij = (rmi+rmj)/2.0;
         rm3ij = rmij*rmij*rmij;
-        epsilonij = sqrt(epsiloni*epsilonj);
-        alphaij = sqrt(alphai*alphaj);
+        epsilonij = Kokkos::Experimental::sqrt(epsiloni*epsilonj);
+        alphaij = Kokkos::Experimental::sqrt(alphai*alphaj);
 
         if (fractionOFAold > 0.0) {
           rm3_old += xMolei_old*xMolej_old*rm3ij;
@@ -2311,8 +2311,8 @@ void PairExp6rxKokkos<DeviceType>::getMixingWeightsVect(const int np_total, int 
 
         const double rmij = (rmi+rmj)/2.0;
         const double rm3ij = rmij*rmij*rmij;
-        const double epsilonij = sqrt(epsiloni*epsilonj);
-        const double alphaij = sqrt(alphai*alphaj);
+        const double epsilonij = Kokkos::Experimental::sqrt(epsiloni*epsilonj);
+        const double alphaij = Kokkos::Experimental::sqrt(alphai*alphaj);
 
         #ifdef KOKKOS_ENABLE_PRAGMA_IVDEP
         #pragma ivdep
@@ -2515,19 +2515,19 @@ void PairExp6rxKokkos<DeviceType>::exponentScaling(double phi, double &epsilon, 
   double powfuch;
 
   if (exponentEpsilon < 0.0) {
-    powfuch = pow(phi,-exponentEpsilon);
+    powfuch = Kokkos::Experimental::pow(phi,-exponentEpsilon);
     if (powfuch<MY_EPSILON) epsilon = 0.0;
     else epsilon *= 1.0/powfuch;
   } else {
-    epsilon *= pow(phi,exponentEpsilon);
+    epsilon *= Kokkos::Experimental::pow(phi,exponentEpsilon);
   }
 
   if (exponentR < 0.0) {
-    powfuch = pow(phi,-exponentR);
+    powfuch = Kokkos::Experimental::pow(phi,-exponentR);
     if (powfuch<MY_EPSILON) rm = 0.0;
     else rm *= 1.0/powfuch;
   } else {
-    rm *= pow(phi,exponentR);
+    rm *= Kokkos::Experimental::pow(phi,exponentR);
   }
 }
 
@@ -2558,7 +2558,7 @@ double PairExp6rxKokkos<DeviceType>::func_rin(const double &alpha) const
   const double a = 3.7682065;
   const double b = -1.4308614;
 
-  function = a+b*sqrt(alpha);
+  function = a+b*Kokkos::Experimental::sqrt(alpha);
   function = expValue(function);
 
   return function;
@@ -2572,7 +2572,7 @@ double PairExp6rxKokkos<DeviceType>::expValue(double value) const
 {
   double returnValue;
   if (value < DBL_MIN_EXP) returnValue = 0.0;
-  else returnValue = exp(value);
+  else returnValue = Kokkos::Experimental::exp(value);
 
   return returnValue;
 }

--- a/src/KOKKOS/pair_gran_hooke_history_kokkos.cpp
+++ b/src/KOKKOS/pair_gran_hooke_history_kokkos.cpp
@@ -358,7 +358,7 @@ void PairGranHookeHistoryKokkos<DeviceType>::operator()(TagPairGranHookeHistoryC
 
     // check for touching neighbors
 
-    const LMP_FLOAT r = sqrt(rsq);
+    const LMP_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const LMP_FLOAT rinv = 1.0/r;
     const LMP_FLOAT rsqinv = 1/rsq;
 
@@ -401,7 +401,7 @@ void PairGranHookeHistoryKokkos<DeviceType>::operator()(TagPairGranHookeHistoryC
     V_FLOAT vtr2 = vt2 - (delx*wr3-delz*wr1);
     V_FLOAT vtr3 = vt3 - (dely*wr1-delx*wr2);
     V_FLOAT vrel = vtr1*vtr1 + vtr2*vtr2 + vtr3*vtr3;
-    vrel = sqrt(vrel);
+    vrel = Kokkos::Experimental::sqrt(vrel);
 
     // shear history effects
 
@@ -413,7 +413,7 @@ void PairGranHookeHistoryKokkos<DeviceType>::operator()(TagPairGranHookeHistoryC
       shear2 += vtr2*dt;
       shear3 += vtr3*dt;
     }
-    X_FLOAT shrmag = sqrt(shear1*shear1 + shear2*shear2 +
+    X_FLOAT shrmag = Kokkos::Experimental::sqrt(shear1*shear1 + shear2*shear2 +
                           shear3*shear3);
 
     // rotate shear displacements
@@ -434,8 +434,8 @@ void PairGranHookeHistoryKokkos<DeviceType>::operator()(TagPairGranHookeHistoryC
 
     // rescale frictional displacements and forces if needed
 
-    F_FLOAT fs = sqrt(fs1*fs1 + fs2*fs2 + fs3*fs3);
-    F_FLOAT fn = xmu * fabs(ccel*r);
+    F_FLOAT fs = Kokkos::Experimental::sqrt(fs1*fs1 + fs2*fs2 + fs3*fs3);
+    F_FLOAT fn = xmu * Kokkos::Experimental::fabs(ccel*r);
 
     if (fs > fn) {
       if (shrmag != 0.0) {

--- a/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_charmm_coul_charmm_kokkos.cpp
@@ -231,7 +231,7 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT forcecoul, switch1;
 
   forcecoul = qqrd2e*qtmp*q(j) *rinv;
@@ -257,7 +257,7 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/, const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT ecoul, switch1;
 
   ecoul = qqrd2e * qtmp * q(j) * rinv;

--- a/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_charmm_coul_long_kokkos.cpp
@@ -244,9 +244,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return forcecoul/rsq;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT rinv = 1.0/r;
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
@@ -281,9 +281,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return ecoul;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
     const F_FLOAT prefactor = qqrd2e * qtmp*q[j]/r;

--- a/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_class2_coul_cut_kokkos.cpp
@@ -161,7 +161,7 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j,
   (void) i;
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r3inv = r2inv*rinv;
   const F_FLOAT r6inv = r3inv*r3inv;
 
@@ -183,7 +183,7 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT forcecoul;
 
   forcecoul = qqrd2e*qtmp*q(j) *rinv;
@@ -203,7 +203,7 @@ compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j,
   (void) i;
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r3inv = r2inv*rinv;
   const F_FLOAT r6inv = r3inv*r3inv;
 
@@ -223,7 +223,7 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
 
   return factor_coul*qqrd2e*qtmp*q(j)*rinv;
 

--- a/src/KOKKOS/pair_lj_class2_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_class2_coul_long_kokkos.cpp
@@ -173,7 +173,7 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j,
   (void) i;
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r3inv = r2inv*rinv;
   const F_FLOAT r6inv = r3inv*r3inv;
 
@@ -208,9 +208,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return forcecoul/rsq;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT rinv = 1.0/r;
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
@@ -234,7 +234,7 @@ compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j,
   (void) i;
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r3inv = r2inv*rinv;
   const F_FLOAT r6inv = r3inv*r3inv;
 
@@ -267,9 +267,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return ecoul;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
     const F_FLOAT prefactor = qqrd2e * qtmp*q[j]/r;

--- a/src/KOKKOS/pair_lj_class2_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_class2_kokkos.cpp
@@ -145,7 +145,7 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
   (void) i;
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r3inv = r2inv*rinv;
   const F_FLOAT r6inv = r3inv*r3inv;
 
@@ -165,7 +165,7 @@ compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
   (void) i;
   (void) j;
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r3inv = r2inv*rinv;
   const F_FLOAT r6inv = r3inv*r3inv;
 

--- a/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_cut_kokkos.cpp
@@ -176,7 +176,7 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT forcecoul;
 
   forcecoul = qqrd2e*qtmp*q(j) *rinv;
@@ -214,7 +214,7 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
 
   return factor_coul*qqrd2e*qtmp*q(j)*rinv;
 

--- a/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_debye_kokkos.cpp
@@ -184,9 +184,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r = 1.0/rinv;
-  const F_FLOAT screening = exp(-kappa*r);
+  const F_FLOAT screening = Kokkos::Experimental::exp(-kappa*r);
   F_FLOAT forcecoul;
 
   forcecoul = qqrd2e * qtmp * q(j) * screening * (kappa + rinv);
@@ -226,9 +226,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   const F_FLOAT r = 1.0/rinv;
-  const F_FLOAT screening = exp(-kappa*r);
+  const F_FLOAT screening = Kokkos::Experimental::exp(-kappa*r);
 
   return factor_coul * qqrd2e * qtmp * q(j) * rinv * screening;
 }

--- a/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_dsf_kokkos.cpp
@@ -221,9 +221,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT prefactor = factor_coul * qqrd2e * qtmp * q(j);
-  const F_FLOAT erfcd = exp(-alpha*alpha*rsq);
+  const F_FLOAT erfcd = Kokkos::Experimental::exp(-alpha*alpha*rsq);
   const F_FLOAT t = 1.0 / (1.0 + EWALD_P*alpha*r);
   const F_FLOAT erfcc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * erfcd;
 
@@ -242,9 +242,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const int& /*itype*/, const int& /*jtype*/,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT prefactor = factor_coul * qqrd2e * qtmp * q(j);
-  const F_FLOAT erfcd = exp(-alpha*alpha*rsq);
+  const F_FLOAT erfcd = Kokkos::Experimental::exp(-alpha*alpha*rsq);
   const F_FLOAT t = 1.0 / (1.0 + EWALD_P*alpha*r);
   const F_FLOAT erfcc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * erfcd;
 

--- a/src/KOKKOS/pair_lj_cut_coul_long_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_cut_coul_long_kokkos.cpp
@@ -204,9 +204,9 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return forcecoul/rsq;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT rinv = 1.0/r;
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
@@ -261,9 +261,9 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
     }
     return ecoul;
   } else {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT grij = g_ewald * r;
-    const F_FLOAT expm2 = exp(-grij*grij);
+    const F_FLOAT expm2 = Kokkos::Experimental::exp(-grij*grij);
     const F_FLOAT t = 1.0 / (1.0 + EWALD_P*grij);
     const F_FLOAT erfc = t * (A1+t*(A2+t*(A3+t*(A4+t*A5)))) * expm2;
     const F_FLOAT prefactor = qqrd2e * qtmp*q[j]/r;

--- a/src/KOKKOS/pair_lj_expand_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_expand_kokkos.cpp
@@ -146,7 +146,7 @@ F_FLOAT PairLJExpandKokkos<DeviceType>::
 compute_fpair(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
               const int& itype, const int& jtype) const {
 
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT rshift = r - (STACKPARAMS?m_params[itype][jtype].shift:params(itype,jtype).shift);
   const F_FLOAT rshiftsq = rshift*rshift;
   const F_FLOAT r2inv = 1.0/rshiftsq;
@@ -167,7 +167,7 @@ F_FLOAT PairLJExpandKokkos<DeviceType>::
 compute_evdwl(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
               const int& itype, const int& jtype) const {
 
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT rshift = r - (STACKPARAMS?m_params[itype][jtype].shift:params(itype,jtype).shift);
   const F_FLOAT rshiftsq = rshift*rshift;
   const F_FLOAT r2inv = 1.0/rshiftsq;

--- a/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_gromacs_coul_gromacs_kokkos.cpp
@@ -171,7 +171,7 @@ compute_fpair(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
      (STACKPARAMS?m_params[itype][jtype].lj2:params(itype,jtype).lj2));
 
   if (rsq > cut_lj_innersq) {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tlj = r - cut_lj_inner;
     const F_FLOAT fswitch = r*tlj*tlj*
             ((STACKPARAMS?m_params[itype][jtype].ljsw1:params(itype,jtype).ljsw1) +
@@ -199,7 +199,7 @@ compute_evdwl(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
   englj += (STACKPARAMS?m_params[itype][jtype].ljsw5:params(itype,jtype).ljsw5);
 
   if (rsq > cut_lj_innersq) {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tlj = r - cut_lj_inner;
     const F_FLOAT eswitch = tlj*tlj*tlj *
             ((STACKPARAMS?m_params[itype][jtype].ljsw3:params(itype,jtype).ljsw3) +
@@ -221,7 +221,7 @@ compute_fcoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT forcecoul = qqrd2e*qtmp*q(j) *rinv;
 
   if (rsq > cut_coul_innersq) {
@@ -245,7 +245,7 @@ compute_ecoul(const F_FLOAT& rsq, const int& /*i*/, const int&j,
               const F_FLOAT& factor_coul, const F_FLOAT& qtmp) const {
 
   const F_FLOAT r2inv = 1.0/rsq;
-  const F_FLOAT rinv = sqrt(r2inv);
+  const F_FLOAT rinv = Kokkos::Experimental::sqrt(r2inv);
   F_FLOAT ecoul = qqrd2e * qtmp * q(j) * (rinv-coulsw5);
 
   if (rsq > cut_coul_innersq) {

--- a/src/KOKKOS/pair_lj_gromacs_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_gromacs_kokkos.cpp
@@ -163,7 +163,7 @@ compute_fpair(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
      (STACKPARAMS?m_params[itype][jtype].lj2:params(itype,jtype).lj2));
 
   if (rsq > (STACKPARAMS?m_params[itype][jtype].cut_inner_sq:params(itype,jtype).cut_inner_sq)) {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tlj = r - (STACKPARAMS?m_params[itype][jtype].cut_inner:params(itype,jtype).cut_inner);
     const F_FLOAT fswitch = r*tlj*tlj*
             ((STACKPARAMS?m_params[itype][jtype].ljsw1:params(itype,jtype).ljsw1) +
@@ -191,7 +191,7 @@ compute_evdwl(const F_FLOAT& rsq, const int& /*i*/, const int& /*j*/,
   englj += (STACKPARAMS?m_params[itype][jtype].ljsw5:params(itype,jtype).ljsw5);
 
   if (rsq > (STACKPARAMS?m_params[itype][jtype].cut_inner_sq:params(itype,jtype).cut_inner_sq)) {
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tlj = r - (STACKPARAMS?m_params[itype][jtype].cut_inner:params(itype,jtype).cut_inner);
     const F_FLOAT eswitch = tlj*tlj*tlj *
             ((STACKPARAMS?m_params[itype][jtype].ljsw3:params(itype,jtype).ljsw3) +

--- a/src/KOKKOS/pair_lj_sdk_kokkos.cpp
+++ b/src/KOKKOS/pair_lj_sdk_kokkos.cpp
@@ -157,7 +157,7 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
 
   } else if (ljt == LJ9_6) {
 
-    const F_FLOAT r3inv = r2inv*sqrt(r2inv);
+    const F_FLOAT r3inv = r2inv*Kokkos::Experimental::sqrt(r2inv);
     const F_FLOAT r6inv = r3inv*r3inv;
     return r6inv*(lj_1*r3inv - lj_2) * r2inv;
 
@@ -171,7 +171,7 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
   const F_FLOAT r4inv=r2inv*r2inv;
   const F_FLOAT r6inv=r2inv*r4inv;
   const F_FLOAT a = ljt==LJ12_4?r4inv:r6inv;
-  const F_FLOAT b = ljt==LJ12_4?r4inv:(ljt==LJ9_6?1.0/sqrt(r2inv):r2inv);
+  const F_FLOAT b = ljt==LJ12_4?r4inv:(ljt==LJ9_6?1.0/Kokkos::Experimental::sqrt(r2inv):r2inv);
   return a* ( lj_1*r6inv*b - lj_2 * r2inv);
 }
 
@@ -195,7 +195,7 @@ compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, c
     return r4inv*(lj_3*r4inv*r4inv - lj_4) - offset;
 
   } else if (ljt == LJ9_6) {
-    const F_FLOAT r3inv = r2inv*sqrt(r2inv);
+    const F_FLOAT r3inv = r2inv*Kokkos::Experimental::sqrt(r2inv);
     const F_FLOAT r6inv = r3inv*r3inv;
     return r6inv*(lj_3*r3inv - lj_4) - offset;
 

--- a/src/KOKKOS/pair_morse_kokkos.cpp
+++ b/src/KOKKOS/pair_morse_kokkos.cpp
@@ -145,16 +145,16 @@ F_FLOAT PairMorseKokkos<DeviceType>::
 compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const {
   (void) i;
   (void) j;
-  const F_FLOAT rr = sqrt(rsq);
+  const F_FLOAT rr = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT r0 = STACKPARAMS ? m_params[itype][jtype].r0 : params(itype,jtype).r0;
   const F_FLOAT d0 = STACKPARAMS ? m_params[itype][jtype].d0 : params(itype,jtype).d0;
   const F_FLOAT aa = STACKPARAMS ? m_params[itype][jtype].alpha : params(itype,jtype).alpha;
   const F_FLOAT dr = rr - r0;
 
-  // U  =  d0 * [ exp( -2*a*(x-r0)) - 2*exp(-a*(x-r0)) ]
-  // f  = -2*a*d0*[ -exp( -2*a*(x-r0) ) + exp( -a*(x-r0) ) ] * grad(r)
-  //    = +2*a*d0*[  exp( -2*a*(x-r0) ) - exp( -a*(x-r0) ) ] * grad(r)
-  const F_FLOAT dexp    = exp( -aa*dr );
+  // U  =  d0 * [ Kokkos::Experimental::exp( -2*a*(x-r0)) - 2*Kokkos::Experimental::exp(-a*(x-r0)) ]
+  // f  = -2*a*d0*[ -Kokkos::Experimental::exp( -2*a*(x-r0) ) + Kokkos::Experimental::exp( -a*(x-r0) ) ] * grad(r)
+  //    = +2*a*d0*[  Kokkos::Experimental::exp( -2*a*(x-r0) ) - Kokkos::Experimental::exp( -a*(x-r0) ) ] * grad(r)
+  const F_FLOAT dexp    = Kokkos::Experimental::exp( -aa*dr );
   const F_FLOAT forcelj = 2*aa*d0*dexp*(dexp-1.0);
 
   return forcelj / rr;
@@ -167,16 +167,16 @@ F_FLOAT PairMorseKokkos<DeviceType>::
 compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const {
   (void) i;
   (void) j;
-  const F_FLOAT rr = sqrt(rsq);
+  const F_FLOAT rr = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT r0 = STACKPARAMS ? m_params[itype][jtype].r0 : params(itype,jtype).r0;
   const F_FLOAT d0 = STACKPARAMS ? m_params[itype][jtype].d0 : params(itype,jtype).d0;
   const F_FLOAT aa = STACKPARAMS ? m_params[itype][jtype].alpha : params(itype,jtype).alpha;
   const F_FLOAT dr = rr - r0;
 
-  // U  =  d0 * [ exp( -2*a*(x-r0)) - 2*exp(-a*(x-r0)) ]
-  // f  = -2*a*d0*[ -exp( -2*a*(x-r0) ) + exp( -a*(x-r0) ) ] * grad(r)
-  //    = +2*a*d0*[  exp( -2*a*(x-r0) ) - exp( -a*(x-r0) ) ] * grad(r)
-  const F_FLOAT dexp    = exp( -aa*dr );
+  // U  =  d0 * [ Kokkos::Experimental::exp( -2*a*(x-r0)) - 2*Kokkos::Experimental::exp(-a*(x-r0)) ]
+  // f  = -2*a*d0*[ -Kokkos::Experimental::exp( -2*a*(x-r0) ) + Kokkos::Experimental::exp( -a*(x-r0) ) ] * grad(r)
+  //    = +2*a*d0*[  Kokkos::Experimental::exp( -2*a*(x-r0) ) - Kokkos::Experimental::exp( -a*(x-r0) ) ] * grad(r)
+  const F_FLOAT dexp    = Kokkos::Experimental::exp( -aa*dr );
 
   return d0 * dexp * ( dexp - 2.0 );
 }

--- a/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_multi_lucy_rx_kokkos.cpp
@@ -341,9 +341,9 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXCompute<NEI
         //A_j = tb->f[jtable];
         A_j = d_table_const.f(tidx,jtable);
 
-        const double rfactor = 1.0-sqrt(rsq/d_cutsq(itype,jtype));
+        const double rfactor = 1.0-Kokkos::Experimental::sqrt(rsq/d_cutsq(itype,jtype));
         fpair = 0.5*(A_i + A_j)*(4.0-3.0*rfactor)*rfactor*rfactor*rfactor;
-        fpair /= sqrt(rsq);
+        fpair /= Kokkos::Experimental::sqrt(rsq);
 
       } else if (TABSTYLE == LINEAR) {
 
@@ -373,14 +373,14 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXCompute<NEI
         //A_j = tb->f[jtable] + fraction_j*tb->df[jtable];
         A_j = d_table_const.f(tidx,jtable) + fraction_j*d_table_const.df(tidx,jtable);
 
-        const double rfactor = 1.0-sqrt(rsq/d_cutsq(itype,jtype));
+        const double rfactor = 1.0-Kokkos::Experimental::sqrt(rsq/d_cutsq(itype,jtype));
         fpair = 0.5*(A_i + A_j)*(4.0-3.0*rfactor)*rfactor*rfactor*rfactor;
-        fpair /= sqrt(rsq);
+        fpair /= Kokkos::Experimental::sqrt(rsq);
 
       } else k_error_flag.template view<DeviceType>()() = 3;
 
-      if (isite1 == isite2) fpair = sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpair;
-      else fpair = (sqrt(mixWtSite1old_i*mixWtSite2old_j) + sqrt(mixWtSite2old_i*mixWtSite1old_j))*fpair;
+      if (isite1 == isite2) fpair = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*fpair;
+      else fpair = (Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j) + Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j))*fpair;
 
       fx_i += delx*fpair;
       fy_i += dely*fpair;
@@ -465,7 +465,7 @@ void PairMultiLucyRXKokkos<DeviceType>::computeLocalDensity()
 
   // Special cut-off values for when there's only one type.
   cutsq_type11 = cutsq[1][1];
-  rcut_type11 = sqrt(cutsq_type11);
+  rcut_type11 = Kokkos::Experimental::sqrt(cutsq_type11);
   factor_type11 = 84.0/(5.0*pi*rcut_type11*rcut_type11*rcut_type11);
 
   // zero out density
@@ -562,7 +562,7 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXComputeLoca
     if (ONE_TYPE) {
       if (rsq < cutsq_type11) {
         const double rcut = rcut_type11;
-        const double r_over_rcut = sqrt(rsq) / rcut;
+        const double r_over_rcut = Kokkos::Experimental::sqrt(rsq) / rcut;
         const double tmpFactor = 1.0 - r_over_rcut;
         const double tmpFactor4 = tmpFactor*tmpFactor*tmpFactor*tmpFactor;
         const double factor = factor_type11*(1.0 + 1.5*r_over_rcut)*tmpFactor4;
@@ -571,10 +571,10 @@ void PairMultiLucyRXKokkos<DeviceType>::operator()(TagPairMultiLucyRXComputeLoca
           a_rho[j] += factor;
       }
     } else if (rsq < d_cutsq(itype,jtype)) {
-      const double rcut = sqrt(d_cutsq(itype,jtype));
-      const double tmpFactor = 1.0-sqrt(rsq)/rcut;
+      const double rcut = Kokkos::Experimental::sqrt(d_cutsq(itype,jtype));
+      const double tmpFactor = 1.0-Kokkos::Experimental::sqrt(rsq)/rcut;
       const double tmpFactor4 = tmpFactor*tmpFactor*tmpFactor*tmpFactor;
-      const double factor = (84.0/(5.0*pi*rcut*rcut*rcut))*(1.0+3.0*sqrt(rsq)/(2.0*rcut))*tmpFactor4;
+      const double factor = (84.0/(5.0*pi*rcut*rcut*rcut))*(1.0+3.0*Kokkos::Experimental::sqrt(rsq)/(2.0*rcut))*tmpFactor4;
       rho_i_contrib += factor;
       if ((NEIGHFLAG==HALF || NEIGHFLAG==HALFTHREAD) && (NEWTON_PAIR || j < nlocal))
         a_rho[j] += factor;

--- a/src/KOKKOS/pair_reaxc_kokkos.cpp
+++ b/src/KOKKOS/pair_reaxc_kokkos.cpp
@@ -345,7 +345,7 @@ void PairReaxCKokkos<DeviceType>::init_md()
   swb = control->nonb_cut;
   enobondsflag = control->enobondsflag;
 
-  if (fabs(swa) > 0.01 )
+  if (Kokkos::Experimental::fabs(swa) > 0.01 )
     error->warning(FLERR,"Warning: non-zero lower Taper-radius cutoff");
 
   if (swb < 0)
@@ -605,23 +605,23 @@ void PairReaxCKokkos<DeviceType>::LR_vdW_Coulomb( int i, int j, double r_ij, LR_
   /*vdWaals Calculations*/
   if (system->reax_param.gp.vdw_type==1 || system->reax_param.gp.vdw_type==3)
     { // shielding
-      powr_vdW1 = pow(r_ij, p_vdW1);
-      powgi_vdW1 = pow( 1.0 / twbp->gamma_w, p_vdW1);
+      powr_vdW1 = Kokkos::Experimental::pow(r_ij, p_vdW1);
+      powgi_vdW1 = Kokkos::Experimental::pow( 1.0 / twbp->gamma_w, p_vdW1);
 
-      fn13 = pow( powr_vdW1 + powgi_vdW1, p_vdW1i );
-      exp1 = exp( twbp->alpha * (1.0 - fn13 / twbp->r_vdW) );
-      exp2 = exp( 0.5 * twbp->alpha * (1.0 - fn13 / twbp->r_vdW) );
+      fn13 = Kokkos::Experimental::pow( powr_vdW1 + powgi_vdW1, p_vdW1i );
+      exp1 = Kokkos::Experimental::exp( twbp->alpha * (1.0 - fn13 / twbp->r_vdW) );
+      exp2 = Kokkos::Experimental::exp( 0.5 * twbp->alpha * (1.0 - fn13 / twbp->r_vdW) );
 
       lr->e_vdW = Tap * twbp->D * (exp1 - 2.0 * exp2);
 
-      dfn13 = pow( powr_vdW1 + powgi_vdW1, p_vdW1i-1.0) * pow(r_ij, p_vdW1-2.0);
+      dfn13 = Kokkos::Experimental::pow( powr_vdW1 + powgi_vdW1, p_vdW1i-1.0) * Kokkos::Experimental::pow(r_ij, p_vdW1-2.0);
 
       lr->CEvd = dTap * twbp->D * (exp1 - 2.0 * exp2) -
         Tap * twbp->D * (twbp->alpha / twbp->r_vdW) * (exp1 - exp2) * dfn13;
     }
   else { // no shielding
-    exp1 = exp( twbp->alpha * (1.0 - r_ij / twbp->r_vdW) );
-    exp2 = exp( 0.5 * twbp->alpha * (1.0 - r_ij / twbp->r_vdW) );
+    exp1 = Kokkos::Experimental::exp( twbp->alpha * (1.0 - r_ij / twbp->r_vdW) );
+    exp2 = Kokkos::Experimental::exp( 0.5 * twbp->alpha * (1.0 - r_ij / twbp->r_vdW) );
 
     lr->e_vdW = Tap * twbp->D * (exp1 - 2.0 * exp2);
     lr->CEvd = dTap * twbp->D * (exp1 - 2.0 * exp2) -
@@ -630,7 +630,7 @@ void PairReaxCKokkos<DeviceType>::LR_vdW_Coulomb( int i, int j, double r_ij, LR_
 
   if (system->reax_param.gp.vdw_type==2 || system->reax_param.gp.vdw_type==3)
     { // inner wall
-      e_core = twbp->ecore * exp(twbp->acore * (1.0-(r_ij/twbp->rcore)));
+      e_core = twbp->ecore * Kokkos::Experimental::exp(twbp->acore * (1.0-(r_ij/twbp->rcore)));
       lr->e_vdW += Tap * e_core;
 
       de_core = -(twbp->acore/twbp->rcore) * e_core;
@@ -653,7 +653,7 @@ void PairReaxCKokkos<DeviceType>::LR_vdW_Coulomb( int i, int j, double r_ij, LR_
 
   /* Coulomb calculations */
   dr3gamij_1 = ( r_ij * r_ij * r_ij + twbp->gamma );
-  dr3gamij_3 = pow( dr3gamij_1 , 0.33333333333333 );
+  dr3gamij_3 = Kokkos::Experimental::pow( dr3gamij_1 , 0.33333333333333 );
 
   tmp = Tap / dr3gamij_3;
   lr->H = EV_to_KCALpMOL * tmp;
@@ -1129,7 +1129,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeLJCoulomb<NEIGHFLAG,
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq > cut_nbsq) continue;
-    const F_FLOAT rij = sqrt(rsq);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq);
 
     // LJ energy/force
     F_FLOAT Tap = d_tap[7] * rij + d_tap[6];
@@ -1154,18 +1154,18 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeLJCoulomb<NEIGHFLAG,
 
     // shielding
     if (vdwflag == 1 || vdwflag == 3) {
-      powr_vdw = pow(rij,gp[28]);
-      powgi_vdw = pow(1.0/gamma_w,gp[28]);
-      fn13 = pow(powr_vdw+powgi_vdw,1.0/gp[28]);
-      exp1 = exp(alpha*(1.0-fn13/r_vdw));
-      exp2 = exp(0.5*alpha*(1.0-fn13/r_vdw));
-      dfn13 = pow(powr_vdw+powgi_vdw,1.0/gp[28]-1.0)*pow(rij,gp[28]-2.0);
+      powr_vdw = Kokkos::Experimental::pow(rij,gp[28]);
+      powgi_vdw = Kokkos::Experimental::pow(1.0/gamma_w,gp[28]);
+      fn13 = Kokkos::Experimental::pow(powr_vdw+powgi_vdw,1.0/gp[28]);
+      exp1 = Kokkos::Experimental::exp(alpha*(1.0-fn13/r_vdw));
+      exp2 = Kokkos::Experimental::exp(0.5*alpha*(1.0-fn13/r_vdw));
+      dfn13 = Kokkos::Experimental::pow(powr_vdw+powgi_vdw,1.0/gp[28]-1.0)*Kokkos::Experimental::pow(rij,gp[28]-2.0);
       etmp = epsilon*(exp1-2.0*exp2);
       evdwl = Tap*etmp;
       fvdwl = dTap*etmp-Tap*epsilon*(alpha/r_vdw)*(exp1-exp2)*dfn13;
     } else {
-      exp1 = exp(alpha*(1.0-rij/r_vdw));
-      exp2 = exp(0.5*alpha*(1.0-rij/r_vdw));
+      exp1 = Kokkos::Experimental::exp(alpha*(1.0-rij/r_vdw));
+      exp2 = Kokkos::Experimental::exp(0.5*alpha*(1.0-rij/r_vdw));
       etmp = epsilon*(exp1-2.0*exp2);
       evdwl = Tap*etmp;
       fvdwl = dTap*etmp-Tap*epsilon*(alpha/r_vdw)*(exp1-exp2)*rij;
@@ -1175,7 +1175,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeLJCoulomb<NEIGHFLAG,
       const F_FLOAT ecore = paramstwbp(itype,jtype).ecore;
       const F_FLOAT acore = paramstwbp(itype,jtype).acore;
       const F_FLOAT rcore = paramstwbp(itype,jtype).rcore;
-      const F_FLOAT e_core = ecore*exp(acore*(1.0-(rij/rcore)));
+      const F_FLOAT e_core = ecore*Kokkos::Experimental::exp(acore*(1.0-(rij/rcore)));
       const F_FLOAT de_core = -(acore/rcore)*e_core;
       evdwl += Tap*e_core;
       fvdwl += dTap*e_core+Tap*de_core/rij;
@@ -1196,7 +1196,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeLJCoulomb<NEIGHFLAG,
     // Coulomb energy/force
     const F_FLOAT shld = paramstwbp(itype,jtype).gamma;
     const F_FLOAT denom1 = rij * rij * rij + shld;
-    const F_FLOAT denom3 = pow(denom1,0.3333333333333);
+    const F_FLOAT denom3 = Kokkos::Experimental::pow(denom1,0.3333333333333);
     const F_FLOAT ecoul = C_ele * qi*qj*Tap/denom3;
     const F_FLOAT fcoul = C_ele * qi*qj*(dTap-Tap*rij/denom1)/denom3;
 
@@ -1277,7 +1277,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTabulatedLJCoulomb<N
     const F_FLOAT rsq = delx*delx + dely*dely + delz*delz;
 
     if (rsq > cut_nbsq) continue;
-    const F_FLOAT rij = sqrt(rsq);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq);
 
     const int tmin  = MIN( itype, jtype );
     const int tmax  = MAX( itype, jtype );
@@ -1500,7 +1500,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBuildListsFull, const int &
     if (rsq > cut_bosq) continue;
 
     // bond_list
-    const F_FLOAT rij = sqrt(rsq);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT p_bo1 = paramstwbp(itype,jtype).p_bo1;
     const F_FLOAT p_bo2 = paramstwbp(itype,jtype).p_bo2;
     const F_FLOAT p_bo3 = paramstwbp(itype,jtype).p_bo3;
@@ -1512,20 +1512,20 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBuildListsFull, const int &
     const F_FLOAT r_pi2 = paramstwbp(itype,jtype).r_pi2;
 
     if (paramssing(itype).r_s > 0.0  && paramssing(jtype).r_s > 0.0) {
-      C12 = p_bo1*pow(rij/r_s,p_bo2);
-      BO_s = (1.0+bo_cut)*exp(C12);
+      C12 = p_bo1*Kokkos::Experimental::pow(rij/r_s,p_bo2);
+      BO_s = (1.0+bo_cut)*Kokkos::Experimental::exp(C12);
     }
     else BO_s = C12 = 0.0;
 
     if (paramssing(itype).r_pi > 0.0  && paramssing(jtype).r_pi > 0.0) {
-      C34 = p_bo3*pow(rij/r_pi,p_bo4);
-      BO_pi = exp(C34);
+      C34 = p_bo3*Kokkos::Experimental::pow(rij/r_pi,p_bo4);
+      BO_pi = Kokkos::Experimental::exp(C34);
     }
     else BO_pi = C34 = 0.0;
 
     if (paramssing(itype).r_pi2 > 0.0  && paramssing(jtype).r_pi2 > 0.0) {
-      C56 = p_bo5*pow(rij/r_pi2,p_bo6);
-      BO_pi2 = exp(C56);
+      C56 = p_bo5*Kokkos::Experimental::pow(rij/r_pi2,p_bo6);
+      BO_pi2 = Kokkos::Experimental::exp(C56);
     }
     else BO_pi2 = C56 = 0.0;
 
@@ -1690,7 +1690,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBuildListsHalf<NEIGHFLAG>, 
     if (rsq > cut_bosq) continue;
 
     // bond_list
-    const F_FLOAT rij = sqrt(rsq);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT p_bo1 = paramstwbp(itype,jtype).p_bo1;
     const F_FLOAT p_bo2 = paramstwbp(itype,jtype).p_bo2;
     const F_FLOAT p_bo3 = paramstwbp(itype,jtype).p_bo3;
@@ -1702,20 +1702,20 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBuildListsHalf<NEIGHFLAG>, 
     const F_FLOAT r_pi2 = paramstwbp(itype,jtype).r_pi2;
 
     if (paramssing(itype).r_s > 0.0  && paramssing(jtype).r_s > 0.0) {
-      C12 = p_bo1*pow(rij/r_s,p_bo2);
-      BO_s = (1.0+bo_cut)*exp(C12);
+      C12 = p_bo1*Kokkos::Experimental::pow(rij/r_s,p_bo2);
+      BO_s = (1.0+bo_cut)*Kokkos::Experimental::exp(C12);
     }
     else BO_s = C12 = 0.0;
 
     if (paramssing(itype).r_pi > 0.0  && paramssing(jtype).r_pi > 0.0) {
-      C34 = p_bo3*pow(rij/r_pi,p_bo4);
-      BO_pi = exp(C34);
+      C34 = p_bo3*Kokkos::Experimental::pow(rij/r_pi,p_bo4);
+      BO_pi = Kokkos::Experimental::exp(C34);
     }
     else BO_pi = C34 = 0.0;
 
     if (paramssing(itype).r_pi2 > 0.0  && paramssing(jtype).r_pi2 > 0.0) {
-      C56 = p_bo5*pow(rij/r_pi2,p_bo6);
-      BO_pi2 = exp(C56);
+      C56 = p_bo5*Kokkos::Experimental::pow(rij/r_pi2,p_bo6);
+      BO_pi2 = Kokkos::Experimental::exp(C56);
     }
     else BO_pi2 = C56 = 0.0;
 
@@ -1867,10 +1867,10 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBondOrder2, const int &ii) 
       d_C4dbopi2(i,j_index) = 0.0;
     } else {
       if (ovc >= 0.001) {
-        exp_p1i = exp(-p_boc1 * d_Deltap[i]);
-        exp_p2i = exp(-p_boc2 * d_Deltap[i]);
-        exp_p1j = exp(-p_boc1 * d_Deltap[j]);
-        exp_p2j = exp(-p_boc2 * d_Deltap[j]);
+        exp_p1i = Kokkos::Experimental::exp(-p_boc1 * d_Deltap[i]);
+        exp_p2i = Kokkos::Experimental::exp(-p_boc2 * d_Deltap[i]);
+        exp_p1j = Kokkos::Experimental::exp(-p_boc1 * d_Deltap[j]);
+        exp_p2j = Kokkos::Experimental::exp(-p_boc2 * d_Deltap[j]);
 
         f2 = exp_p1i + exp_p1j;
         f3 = -1.0/p_boc2*log(0.5*(exp_p2i+exp_p2j));
@@ -1890,8 +1890,8 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBondOrder2, const int &ii) 
       }
 
       if (v13cor >= 0.001) {
-        exp_f4 =exp(-(p_boc4*(d_BO(i,j_index)*d_BO(i,j_index))-d_Deltap_boc[i])*p_boc3+p_boc5);
-        exp_f5 =exp(-(p_boc4*(d_BO(i,j_index)*d_BO(i,j_index))-d_Deltap_boc[j])*p_boc3+p_boc5);
+        exp_f4 =Kokkos::Experimental::exp(-(p_boc4*(d_BO(i,j_index)*d_BO(i,j_index))-d_Deltap_boc[i])*p_boc3+p_boc5);
+        exp_f5 =Kokkos::Experimental::exp(-(p_boc4*(d_BO(i,j_index)*d_BO(i,j_index))-d_Deltap_boc[j])*p_boc3+p_boc5);
         f4 = 1. / (1. + exp_f4);
         f5 = 1. / (1. + exp_f5);
         f4f5 = f4 * f5;
@@ -1967,7 +1967,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxBondOrder3, const int &ii) 
   d_Delta_boc[i] = d_total_bo[i] - paramssing(itype).valency_boc;
 
   const F_FLOAT vlpex = Delta_e - 2.0 * (int)(Delta_e/2.0);
-  const F_FLOAT explp1 = exp(-gp[15] * SQR(2.0 + vlpex));
+  const F_FLOAT explp1 = Kokkos::Experimental::exp(-gp[15] * SQR(2.0 + vlpex));
   const F_FLOAT nlp = explp1 - (int)(Delta_e / 2.0);
   d_Delta_lp[i] = paramssing(itype).nlp_opt - nlp;
   const F_FLOAT Clp = 2.0 * gp[15] * explp1 * (2.0 + vlpex);
@@ -2053,7 +2053,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeMulti2<NEIGHFLAG,EVF
 
   // lone pair
   const F_FLOAT p_lp2 = paramssing(itype).p_lp2;
-  const F_FLOAT expvd2 = exp( -75 * d_Delta_lp[i]);
+  const F_FLOAT expvd2 = Kokkos::Experimental::exp( -75 * d_Delta_lp[i]);
   const F_FLOAT inv_expvd2 = 1.0 / (1.0+expvd2);
 
   int numbonds = d_bo_num[i];
@@ -2072,11 +2072,11 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeMulti2<NEIGHFLAG,EVF
   //if (eflag_atom) this->template e_tally<NEIGHFLAG>(ev,i,i,e_lp);
 
   // over coordination
-  const F_FLOAT exp_ovun1 = p_ovun3 * exp( p_ovun4 * d_sum_ovun(i,2) );
+  const F_FLOAT exp_ovun1 = p_ovun3 * Kokkos::Experimental::exp( p_ovun4 * d_sum_ovun(i,2) );
   const F_FLOAT inv_exp_ovun1 = 1.0 / (1 + exp_ovun1);
   const F_FLOAT Delta_lpcorr  = d_Delta[i] - (dfvl * d_Delta_lp_temp[i]) * inv_exp_ovun1;
 
-  const F_FLOAT exp_ovun2 = exp( p_ovun2 * Delta_lpcorr );
+  const F_FLOAT exp_ovun2 = Kokkos::Experimental::exp( p_ovun2 * Delta_lpcorr );
   const F_FLOAT inv_exp_ovun2 = 1.0 / (1.0 + exp_ovun2);
   const F_FLOAT DlpVi = 1.0 / (Delta_lpcorr + val_i + 1e-8);
 
@@ -2095,8 +2095,8 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeMulti2<NEIGHFLAG,EVF
   // under coordination
 
   const F_FLOAT exp_ovun2n = 1.0 / exp_ovun2;
-  const F_FLOAT exp_ovun6 = exp( p_ovun6 * Delta_lpcorr );
-  const F_FLOAT exp_ovun8 = p_ovun7 * exp(p_ovun8 * d_sum_ovun(i,2));
+  const F_FLOAT exp_ovun6 = Kokkos::Experimental::exp( p_ovun6 * Delta_lpcorr );
+  const F_FLOAT exp_ovun8 = p_ovun7 * Kokkos::Experimental::exp(p_ovun8 * d_sum_ovun(i,2));
   const F_FLOAT inv_exp_ovun2n = 1.0 / (1.0 + exp_ovun2n);
   const F_FLOAT inv_exp_ovun8 = 1.0 / (1.0 + exp_ovun8);
 
@@ -2139,11 +2139,11 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeMulti2<NEIGHFLAG,EVF
     // multibody lone pair: correction for C2
     if (p_lp3 > 0.001 && imass == 12.0 && jmass == 12.0) {
       const F_FLOAT Di = d_Delta[i];
-      const F_FLOAT vov3 = d_BO(i,j_index) - Di - 0.040*pow(Di,4.0);
+      const F_FLOAT vov3 = d_BO(i,j_index) - Di - 0.040*Kokkos::Experimental::pow(Di,4.0);
       if (vov3 > 3.0) {
         const F_FLOAT e_lph = p_lp3 * (vov3-3.0)*(vov3-3.0);
         const F_FLOAT deahu2dbo = 2.0 * p_lp3 * (vov3 - 3.0);
-        const F_FLOAT deahu2dsbo = 2.0 * p_lp3 * (vov3 - 3.0) * (-1.0 - 0.16 * pow(Di,3.0));
+        const F_FLOAT deahu2dsbo = 2.0 * p_lp3 * (vov3 - 3.0) * (-1.0 - 0.16 * Kokkos::Experimental::pow(Di,3.0));
         d_Cdbo(i,j_index) += deahu2dbo;
         CdDelta_i += deahu2dsbo;
 
@@ -2245,12 +2245,12 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
     temp = SQR(bo_ij);
     temp *= temp;
     temp *= temp;
-    prod_SBO *= exp( -temp );
+    prod_SBO *= Kokkos::Experimental::exp( -temp );
   }
 
   const F_FLOAT Delta_e = d_total_bo[i] - paramssing(itype).valency_e;
   const F_FLOAT vlpex = Delta_e - 2.0 * (int)(Delta_e/2.0);
-  const F_FLOAT explp1 = exp(-gp[15] * SQR(2.0 + vlpex));
+  const F_FLOAT explp1 = Kokkos::Experimental::exp(-gp[15] * SQR(2.0 + vlpex));
   const F_FLOAT nlp = explp1 - (int)(Delta_e / 2.0);
   if (vlpex >= 0.0) {
     vlpadj = 0.0;
@@ -2267,16 +2267,16 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
     SBO2 = 0.0;
     CSBO2 = 0.0;
   } else if (SBO > 0.0 && SBO <= 1.0) {
-    SBO2 = pow( SBO, p_val9 );
-    CSBO2 = p_val9 * pow( SBO, p_val9 - 1.0 );
+    SBO2 = Kokkos::Experimental::pow( SBO, p_val9 );
+    CSBO2 = p_val9 * Kokkos::Experimental::pow( SBO, p_val9 - 1.0 );
   } else if (SBO > 1.0 && SBO < 2.0) {
-    SBO2 = 2.0 - pow( 2.0-SBO, p_val9 );
-    CSBO2 = p_val9 * pow( 2.0 - SBO, p_val9 - 1.0 );
+    SBO2 = 2.0 - Kokkos::Experimental::pow( 2.0-SBO, p_val9 );
+    CSBO2 = p_val9 * Kokkos::Experimental::pow( 2.0 - SBO, p_val9 - 1.0 );
   } else {
     SBO2 = 2.0;
     CSBO2 = 0.0;
   }
-  expval6 = exp( p_val6 * d_Delta_boc[i] );
+  expval6 = Kokkos::Experimental::exp( p_val6 * d_Delta_boc[i] );
 
   F_FLOAT CdDelta_i = 0.0;
   F_FLOAT fitmp[3],fjtmp[3];
@@ -2290,7 +2290,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
     delij[1] = x(j,1) - ytmp;
     delij[2] = x(j,2) - ztmp;
     const F_FLOAT rsqij = delij[0]*delij[0] + delij[1]*delij[1] + delij[2]*delij[2];
-    rij = sqrt(rsqij);
+    rij = Kokkos::Experimental::sqrt(rsqij);
     bo_ij = d_BO(i,j_index);
     const int i_index = maxbo+j_index;
 
@@ -2314,7 +2314,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
       delik[1] = x(k,1) - ytmp;
       delik[2] = x(k,2) - ztmp;
       const F_FLOAT rsqik = delik[0]*delik[0] + delik[1]*delik[1] + delik[2]*delik[2];
-      const F_FLOAT rik = sqrt(rsqik);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsqik);
       bo_ik = d_BO(i,k_index);
       BOA_ik   = bo_ik - thb_cut;
 
@@ -2327,7 +2327,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
       cos_theta = (delij[0]*delik[0]+delij[1]*delik[1]+delij[2]*delik[2])/(rij*rik);
       if (cos_theta > 1.0) cos_theta  = 1.0;
       if (cos_theta < -1.0) cos_theta  = -1.0;
-      theta = acos(cos_theta);
+      theta = Kokkos::Experimental::acos(cos_theta);
 
       const F_FLOAT inv_dists = 1.0 / (rij * rik);
       const F_FLOAT Cdot_inv3 = cos_theta * inv_dists * inv_dists;
@@ -2338,11 +2338,11 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
         dcos_theta_dk[t] = delij[t] * inv_dists - Cdot_inv3 * rsqij * delik[t];
       }
 
-      sin_theta = sin(theta);
+      sin_theta = Kokkos::Experimental::sin(theta);
       if (sin_theta < 1.0e-5) sin_theta = 1.0e-5;
       p_val1 = paramsthbp(jtype,itype,ktype).p_val1;
 
-      if (fabs(p_val1) <= 0.001) continue;
+      if (Kokkos::Experimental::fabs(p_val1) <= 0.001) continue;
 
       // ANGLE ENERGY
 
@@ -2352,21 +2352,21 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
       p_val7 = paramsthbp(jtype,itype,ktype).p_val7;
       theta_00 = paramsthbp(jtype,itype,ktype).theta_00;
 
-      exp3ij = exp( -p_val3 * pow( BOA_ij, p_val4 ) );
+      exp3ij = Kokkos::Experimental::exp( -p_val3 * Kokkos::Experimental::pow( BOA_ij, p_val4 ) );
       f7_ij = 1.0 - exp3ij;
-      Cf7ij = p_val3 * p_val4 * pow( BOA_ij, p_val4 - 1.0 ) * exp3ij;
-      exp3jk = exp( -p_val3 * pow( BOA_ik, p_val4 ) );
+      Cf7ij = p_val3 * p_val4 * Kokkos::Experimental::pow( BOA_ij, p_val4 - 1.0 ) * exp3ij;
+      exp3jk = Kokkos::Experimental::exp( -p_val3 * Kokkos::Experimental::pow( BOA_ik, p_val4 ) );
       f7_jk = 1.0 - exp3jk;
-      Cf7jk = p_val3 * p_val4 * pow( BOA_ik, p_val4 - 1.0 ) * exp3jk;
-      expval7 = exp( -p_val7 * d_Delta_boc[i] );
+      Cf7jk = p_val3 * p_val4 * Kokkos::Experimental::pow( BOA_ik, p_val4 - 1.0 ) * exp3jk;
+      expval7 = Kokkos::Experimental::exp( -p_val7 * d_Delta_boc[i] );
       trm8 = 1.0 + expval6 + expval7;
       f8_Dj = p_val5 - ( (p_val5 - 1.0) * (2.0 + expval6) / trm8 );
       Cf8j = ((1.0 - p_val5) / (trm8*trm8)) *
        (p_val6 * expval6 * trm8 - (2.0 + expval6) * ( p_val6*expval6 - p_val7*expval7));
-      theta_0 = 180.0 - theta_00 * (1.0 - exp(-p_val10 * (2.0 - SBO2)));
+      theta_0 = 180.0 - theta_00 * (1.0 - Kokkos::Experimental::exp(-p_val10 * (2.0 - SBO2)));
       theta_0 = theta_0*constPI/180.0;
 
-      expval2theta  = exp( -p_val2 * (theta_0-theta)*(theta_0-theta) );
+      expval2theta  = Kokkos::Experimental::exp( -p_val2 * (theta_0-theta)*(theta_0-theta) );
       if (p_val1 >= 0)
         expval12theta = p_val1 * (1.0 - expval2theta);
       else // To avoid linear Me-H-Me angles (6/6/06)
@@ -2376,7 +2376,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
       CEval2 = Cf7jk * f7_ij * f8_Dj * expval12theta;
       CEval3 = Cf8j  * f7_ij * f7_jk * expval12theta;
       CEval4 = -2.0 * p_val1 * p_val2 * f7_ij * f7_jk * f8_Dj * expval2theta * (theta_0 - theta);
-      Ctheta_0 = p_val10 * theta_00*constPI/180.0 * exp( -p_val10 * (2.0 - SBO2) );
+      Ctheta_0 = p_val10 * theta_00*constPI/180.0 * Kokkos::Experimental::exp( -p_val10 * (2.0 - SBO2) );
       CEval5 = -CEval4 * Ctheta_0 * CSBO2;
       CEval6 = CEval5 * dSBO1;
       CEval7 = CEval5 * dSBO2;
@@ -2389,10 +2389,10 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
 
       p_pen1 = paramsthbp(jtype,itype,ktype).p_pen1;
 
-      exp_pen2ij = exp( -p_pen2 * (BOA_ij - 2.0)*(BOA_ij - 2.0) );
-      exp_pen2jk = exp( -p_pen2 * (BOA_ik - 2.0)*(BOA_ik - 2.0) );
-      exp_pen3 = exp( -p_pen3 * d_Delta[i] );
-      exp_pen4 = exp(  p_pen4 * d_Delta[i] );
+      exp_pen2ij = Kokkos::Experimental::exp( -p_pen2 * (BOA_ij - 2.0)*(BOA_ij - 2.0) );
+      exp_pen2jk = Kokkos::Experimental::exp( -p_pen2 * (BOA_ik - 2.0)*(BOA_ik - 2.0) );
+      exp_pen3 = Kokkos::Experimental::exp( -p_pen3 * d_Delta[i] );
+      exp_pen4 = Kokkos::Experimental::exp(  p_pen4 * d_Delta[i] );
       trm_pen34 = 1.0 + exp_pen3 + exp_pen4;
       f9_Dj = (2.0 + exp_pen3 ) / trm_pen34;
       Cf9j = (-p_pen3 * exp_pen3 * trm_pen34 - (2.0 + exp_pen3) *
@@ -2409,12 +2409,12 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeAngular<NEIGHFLAG,EV
       // ConjAngle energy
 
       p_coa1 = paramsthbp(jtype,itype,ktype).p_coa1;
-      exp_coa2 = exp( p_coa2 * Delta_val );
+      exp_coa2 = Kokkos::Experimental::exp( p_coa2 * Delta_val );
       e_coa = p_coa1 / (1. + exp_coa2) *
-              exp( -p_coa3 * SQR(d_total_bo[j]-BOA_ij) ) *
-              exp( -p_coa3 * SQR(d_total_bo[k]-BOA_ik) ) *
-              exp( -p_coa4 * SQR(BOA_ij - 1.5) ) *
-              exp( -p_coa4 * SQR(BOA_ik - 1.5) );
+              Kokkos::Experimental::exp( -p_coa3 * SQR(d_total_bo[j]-BOA_ij) ) *
+              Kokkos::Experimental::exp( -p_coa3 * SQR(d_total_bo[k]-BOA_ik) ) *
+              Kokkos::Experimental::exp( -p_coa4 * SQR(BOA_ij - 1.5) ) *
+              Kokkos::Experimental::exp( -p_coa4 * SQR(BOA_ik - 1.5) );
 
       CEcoa1 = -2 * p_coa4 * (BOA_ij - 1.5) * e_coa;
       CEcoa2 = -2 * p_coa4 * (BOA_ik - 1.5) * e_coa;
@@ -2562,14 +2562,14 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
     delij[1] = x(j,1) - ytmp;
     delij[2] = x(j,2) - ztmp;
     const F_FLOAT rsqij = delij[0]*delij[0] + delij[1]*delij[1] + delij[2]*delij[2];
-    const F_FLOAT rij = sqrt(rsqij);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsqij);
 
     BOA_ij = bo_ij - thb_cut;
     Delta_j = d_Delta_boc[j];
-    exp_tor2_ij = exp( -p_tor2 * BOA_ij );
-    exp_cot2_ij = exp( -p_cot2 * SQR(BOA_ij - 1.5) );
-    exp_tor3_DiDj = exp( -p_tor3 * (Delta_i + Delta_j) );
-    exp_tor4_DiDj = exp( p_tor4  * (Delta_i + Delta_j) );
+    exp_tor2_ij = Kokkos::Experimental::exp( -p_tor2 * BOA_ij );
+    exp_cot2_ij = Kokkos::Experimental::exp( -p_cot2 * SQR(BOA_ij - 1.5) );
+    exp_tor3_DiDj = Kokkos::Experimental::exp( -p_tor3 * (Delta_i + Delta_j) );
+    exp_tor4_DiDj = Kokkos::Experimental::exp( p_tor4  * (Delta_i + Delta_j) );
     exp_tor34_inv = 1.0 / (1.0 + exp_tor3_DiDj + exp_tor4_DiDj);
     f11_DiDj = (2.0 + exp_tor3_DiDj) * exp_tor34_inv;
 
@@ -2592,12 +2592,12 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
       BOA_ik = bo_ik - thb_cut;
       for (int d = 0; d < 3; d ++) delik[d] = x(k,d) - x(i,d);
       const F_FLOAT rsqik = delik[0]*delik[0] + delik[1]*delik[1] + delik[2]*delik[2];
-      const F_FLOAT rik = sqrt(rsqik);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsqik);
 
       cos_ijk = (delij[0]*delik[0]+delij[1]*delik[1]+delij[2]*delik[2])/(rij*rik);
       if (cos_ijk > 1.0) cos_ijk  = 1.0;
       if (cos_ijk < -1.0) cos_ijk  = -1.0;
-      theta_ijk = acos(cos_ijk);
+      theta_ijk = Kokkos::Experimental::acos(cos_ijk);
 
       // dcos_ijk
       const F_FLOAT inv_dists = 1.0 / (rij * rik);
@@ -2609,15 +2609,15 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
         dcos_ijk_dk[d] = delij[d] * inv_dists - cos_ijk_tmp * rsqij * delik[d];
       }
 
-      sin_ijk = sin( theta_ijk );
+      sin_ijk = Kokkos::Experimental::sin( theta_ijk );
       if (sin_ijk >= 0 && sin_ijk <= 1e-10)
         tan_ijk_i = cos_ijk / 1e-10;
       else if (sin_ijk <= 0 && sin_ijk >= -1e-10)
         tan_ijk_i = -cos_ijk / 1e-10;
       else tan_ijk_i = cos_ijk / sin_ijk;
 
-      exp_tor2_ik = exp( -p_tor2 * BOA_ik );
-      exp_cot2_ik = exp( -p_cot2 * SQR(BOA_ik -1.5) );
+      exp_tor2_ik = Kokkos::Experimental::exp( -p_tor2 * BOA_ik );
+      exp_cot2_ik = Kokkos::Experimental::exp( -p_cot2 * SQR(BOA_ik -1.5) );
 
       for (int l = 0; l < 3; l++) fktmp[l] = 0.0;
 
@@ -2633,13 +2633,13 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
 
         for (int d = 0; d < 3; d ++) deljl[d] = x(l,d) - x(j,d);
         const F_FLOAT rsqjl = deljl[0]*deljl[0] + deljl[1]*deljl[1] + deljl[2]*deljl[2];
-        const F_FLOAT rjl = sqrt(rsqjl);
+        const F_FLOAT rjl = Kokkos::Experimental::sqrt(rsqjl);
         BOA_jl = bo_jl - thb_cut;
 
         cos_jil = -(delij[0]*deljl[0]+delij[1]*deljl[1]+delij[2]*deljl[2])/(rij*rjl);
         if (cos_jil > 1.0) cos_jil  = 1.0;
         if (cos_jil < -1.0) cos_jil  = -1.0;
-        theta_jil = acos(cos_jil);
+        theta_jil = Kokkos::Experimental::acos(cos_jil);
 
         // dcos_jil
         const F_FLOAT inv_distjl = 1.0 / (rij * rjl);
@@ -2651,7 +2651,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
           dcos_jil_dk[d] = -delij[d] * inv_distjl - cos_jil_tmp * rsqij * deljl[d];
         }
 
-        sin_jil = sin( theta_jil );
+        sin_jil = Kokkos::Experimental::sin( theta_jil );
         if (sin_jil >= 0 && sin_jil <= 1e-10)
           tan_jil_i = cos_jil / 1e-10;
         else if (sin_jil <= 0 && sin_jil >= -1e-10)
@@ -2660,7 +2660,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
 
         for (int d = 0; d < 3; d ++) dellk[d] = x(k,d) - x(l,d);
         const F_FLOAT rsqlk = dellk[0]*dellk[0] + dellk[1]*dellk[1] + dellk[2]*dellk[2];
-        const F_FLOAT rlk = sqrt(rsqlk);
+        const F_FLOAT rlk = Kokkos::Experimental::sqrt(rsqlk);
 
         F_FLOAT unnorm_cos_omega, unnorm_sin_omega, omega;
         F_FLOAT htra, htrb, htrc, hthd, hthe, hnra, hnrc, hnhd, hnhe;
@@ -2731,9 +2731,9 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
         for (int d = 0; d < 3; d++) dcos_omega_dl[d] += (hthe-arg*hnhe)/sin_jil_rnd * -dcos_jil_dk[d];
         for (int d = 0; d < 3; d++) dcos_omega_dl[d] *= 2.0/poem;
 
-        cos_omega = cos( omega );
-        cos2omega = cos( 2. * omega );
-        cos3omega = cos( 3. * omega );
+        cos_omega = Kokkos::Experimental::cos( omega );
+        cos2omega = Kokkos::Experimental::cos( 2. * omega );
+        cos3omega = Kokkos::Experimental::cos( 3. * omega );
 
         // torsion energy
 
@@ -2743,9 +2743,9 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeTorsion<NEIGHFLAG,EV
         V2 = paramsfbp(ktype,itype,jtype,ltype).V2;
         V3 = paramsfbp(ktype,itype,jtype,ltype).V3;
 
-        exp_tor1 = exp(p_tor1 * SQR(2.0 - d_BO_pi(i,j_index) - f11_DiDj));
-        exp_tor2_jl = exp(-p_tor2 * BOA_jl);
-        exp_cot2_jl = exp(-p_cot2 * SQR(BOA_jl - 1.5) );
+        exp_tor1 = Kokkos::Experimental::exp(p_tor1 * SQR(2.0 - d_BO_pi(i,j_index) - f11_DiDj));
+        exp_tor2_jl = Kokkos::Experimental::exp(-p_tor2 * BOA_jl);
+        exp_cot2_jl = Kokkos::Experimental::exp(-p_cot2 * SQR(BOA_jl - 1.5) );
         fn10 = (1.0 - exp_tor2_ik) * (1.0 - exp_tor2_ij) * (1.0 - exp_tor2_jl);
 
         CV = 0.5 * (V1 * (1.0 + cos_omega) + V2 * exp_tor1 * (1.0 - cos2omega) + V3 * (1.0 + cos3omega) );
@@ -2918,7 +2918,7 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeHydrogen<NEIGHFLAG,E
     delik[1] = x(k,1) - ytmp;
     delik[2] = x(k,2) - ztmp;
     const F_FLOAT rsqik = delik[0]*delik[0] + delik[1]*delik[1] + delik[2]*delik[2];
-    const F_FLOAT rik = sqrt(rsqik);
+    const F_FLOAT rik = Kokkos::Experimental::sqrt(rsqik);
 
     for (int itr = 0; itr < top; itr++) {
       const int jj = hblist[itr];
@@ -2935,13 +2935,13 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeHydrogen<NEIGHFLAG,E
       delij[1] = x(j,1) - ytmp;
       delij[2] = x(j,2) - ztmp;
       const F_FLOAT rsqij = delij[0]*delij[0] + delij[1]*delij[1] + delij[2]*delij[2];
-      const F_FLOAT rij = sqrt(rsqij);
+      const F_FLOAT rij = Kokkos::Experimental::sqrt(rsqij);
 
       // theta and derivatives
       cos_theta = (delij[0]*delik[0]+delij[1]*delik[1]+delij[2]*delik[2])/(rij*rik);
       if (cos_theta > 1.0) cos_theta  = 1.0;
       if (cos_theta < -1.0) cos_theta  = -1.0;
-      theta = acos(cos_theta);
+      theta = Kokkos::Experimental::acos(cos_theta);
 
       const F_FLOAT inv_dists = 1.0 / (rij * rik);
       const F_FLOAT Cdot_inv3 = cos_theta * inv_dists * inv_dists;
@@ -2958,12 +2958,12 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeHydrogen<NEIGHFLAG,E
       const F_FLOAT p_hb3 = paramshbp(jtype,itype,ktype).p_hb3;
       const F_FLOAT r0_hb = paramshbp(jtype,itype,ktype).r0_hb;
 
-      sin_theta2 = sin(theta/2.0);
+      sin_theta2 = Kokkos::Experimental::sin(theta/2.0);
       sin_xhz4 = SQR(sin_theta2);
       sin_xhz4 *= sin_xhz4;
       cos_xhz1 = (1.0 - cos_theta);
-      exp_hb2 = exp(-p_hb2 * bo_ij);
-      exp_hb3 = exp(-p_hb3 * (r0_hb/rik + rik/r0_hb - 2.0));
+      exp_hb2 = Kokkos::Experimental::exp(-p_hb2 * bo_ij);
+      exp_hb3 = Kokkos::Experimental::exp(-p_hb3 * (r0_hb/rik + rik/r0_hb - 2.0));
 
       e_hb = p_hb1 * (1.0 - exp_hb2) * exp_hb3 * sin_xhz4;
       if (eflag) ev.ereax[8] += e_hb;
@@ -3117,8 +3117,8 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeBond1<NEIGHFLAG,EVFL
     const F_FLOAT BO_pi2_i = d_BO_pi2(i,j_index);
 
     if (BO_s_i == 0.0) pow_BOs_be2 = 0.0;
-    else pow_BOs_be2 = pow(BO_s_i,p_be2);
-    exp_be12 = exp(p_be1*(1.0-pow_BOs_be2));
+    else pow_BOs_be2 = Kokkos::Experimental::pow(BO_s_i,p_be2);
+    exp_be12 = Kokkos::Experimental::exp(p_be1*(1.0-pow_BOs_be2));
     CEbo = -De_s*exp_be12*(1.0-p_be1*p_be2*pow_BOs_be2);
     ebond = -De_s*BO_s_i*exp_be12
                               -De_p*BO_pi_i
@@ -3139,10 +3139,10 @@ void PairReaxCKokkos<DeviceType>::operator()(PairReaxComputeBond1<NEIGHFLAG,EVFL
     if (BO_i >= 1.00) {
       if (gp[37] == 2 || (imass == 12.0000 && jmass == 15.9990) ||
                          (jmass == 12.0000 && imass == 15.9990)) {
-        const F_FLOAT exphu = exp(-gp[7] * SQR(BO_i - 2.50) );
-        const F_FLOAT exphua1 = exp(-gp[3] * (d_total_bo[i]-BO_i));
-        const F_FLOAT exphub1 = exp(-gp[3] * (d_total_bo[j]-BO_i));
-        const F_FLOAT exphuov = exp(gp[4] * (d_Delta[i] + d_Delta[j]));
+        const F_FLOAT exphu = Kokkos::Experimental::exp(-gp[7] * SQR(BO_i - 2.50) );
+        const F_FLOAT exphua1 = Kokkos::Experimental::exp(-gp[3] * (d_total_bo[i]-BO_i));
+        const F_FLOAT exphub1 = Kokkos::Experimental::exp(-gp[3] * (d_total_bo[j]-BO_i));
+        const F_FLOAT exphuov = Kokkos::Experimental::exp(gp[4] * (d_Delta[i] + d_Delta[j]));
         const F_FLOAT hulpov = 1.0 / (1.0 + 25.0 * exphuov);
         estriph = gp[10] * exphu * hulpov * (exphua1 + exphub1);
 

--- a/src/KOKKOS/pair_sw_kokkos.cpp
+++ b/src/KOKKOS/pair_sw_kokkos.cpp
@@ -670,13 +670,13 @@ void PairSWKokkos<DeviceType>::twobody(const Param& param, const F_FLOAT& rsq, F
 {
   F_FLOAT r,rinvsq,rp,rq,rainv,rainvsq,expsrainv;
 
-  r = sqrt(rsq);
+  r = Kokkos::Experimental::sqrt(rsq);
   rinvsq = 1.0/rsq;
-  rp = pow(r,-param.powerp);
-  rq = pow(r,-param.powerq);
+  rp = Kokkos::Experimental::pow(r,-param.powerp);
+  rq = Kokkos::Experimental::pow(r,-param.powerq);
   rainv = 1.0 / (r - param.cut);
   rainvsq = rainv*rainv*r;
-  expsrainv = exp(param.sigma * rainv);
+  expsrainv = Kokkos::Experimental::exp(param.sigma * rainv);
   fforce = (param.c1*rp - param.c2*rq +
             (param.c3*rp -param.c4*rq) * rainvsq) * expsrainv * rinvsq;
   if (eflag) eng = (param.c5*rp - param.c6*rq) * expsrainv;
@@ -696,19 +696,19 @@ void PairSWKokkos<DeviceType>::threebody(const Param& paramij, const Param& para
   F_FLOAT rinv12,cs,delcs,delcssq,facexp,facrad,frad1,frad2;
   F_FLOAT facang,facang12,csfacang,csfac1,csfac2;
 
-  r1 = sqrt(rsq1);
+  r1 = Kokkos::Experimental::sqrt(rsq1);
   rinvsq1 = 1.0/rsq1;
   rainv1 = 1.0/(r1 - paramij.cut);
   gsrainv1 = paramij.sigma_gamma * rainv1;
   gsrainvsq1 = gsrainv1*rainv1/r1;
-  expgsrainv1 = exp(gsrainv1);
+  expgsrainv1 = Kokkos::Experimental::exp(gsrainv1);
 
-  r2 = sqrt(rsq2);
+  r2 = Kokkos::Experimental::sqrt(rsq2);
   rinvsq2 = 1.0/rsq2;
   rainv2 = 1.0/(r2 - paramik.cut);
   gsrainv2 = paramik.sigma_gamma * rainv2;
   gsrainvsq2 = gsrainv2*rainv2/r2;
-  expgsrainv2 = exp(gsrainv2);
+  expgsrainv2 = Kokkos::Experimental::exp(gsrainv2);
 
   rinv12 = 1.0/(r1*r2);
   cs = (delr1[0]*delr2[0] + delr1[1]*delr2[1] + delr1[2]*delr2[2]) * rinv12;
@@ -717,7 +717,7 @@ void PairSWKokkos<DeviceType>::threebody(const Param& paramij, const Param& para
 
   facexp = expgsrainv1*expgsrainv2;
 
-  // facrad = sqrt(paramij.lambda_epsilon*paramik.lambda_epsilon) *
+  // facrad = Kokkos::Experimental::sqrt(paramij.lambda_epsilon*paramik.lambda_epsilon) *
   //          facexp*delcssq;
 
   facrad = paramijk.lambda_epsilon * facexp*delcssq;
@@ -753,17 +753,17 @@ void PairSWKokkos<DeviceType>::threebodyj(const Param& paramij, const Param& par
   F_FLOAT rinv12,cs,delcs,delcssq,facexp,facrad,frad1;
   F_FLOAT facang,facang12,csfacang,csfac1;
 
-  r1 = sqrt(rsq1);
+  r1 = Kokkos::Experimental::sqrt(rsq1);
   rinvsq1 = 1.0/rsq1;
   rainv1 = 1.0/(r1 - paramij.cut);
   gsrainv1 = paramij.sigma_gamma * rainv1;
   gsrainvsq1 = gsrainv1*rainv1/r1;
-  expgsrainv1 = exp(gsrainv1);
+  expgsrainv1 = Kokkos::Experimental::exp(gsrainv1);
 
-  r2 = sqrt(rsq2);
+  r2 = Kokkos::Experimental::sqrt(rsq2);
   rainv2 = 1.0/(r2 - paramik.cut);
   gsrainv2 = paramik.sigma_gamma * rainv2;
-  expgsrainv2 = exp(gsrainv2);
+  expgsrainv2 = Kokkos::Experimental::exp(gsrainv2);
 
   rinv12 = 1.0/(r1*r2);
   cs = (delr1[0]*delr2[0] + delr1[1]*delr2[1] + delr1[2]*delr2[2]) * rinv12;
@@ -772,7 +772,7 @@ void PairSWKokkos<DeviceType>::threebodyj(const Param& paramij, const Param& par
 
   facexp = expgsrainv1*expgsrainv2;
 
-  // facrad = sqrt(paramij.lambda_epsilon*paramik.lambda_epsilon) *
+  // facrad = Kokkos::Experimental::sqrt(paramij.lambda_epsilon*paramik.lambda_epsilon) *
   //          facexp*delcssq;
 
   facrad = paramijk.lambda_epsilon * facexp*delcssq;

--- a/src/KOKKOS/pair_table_rx_kokkos.cpp
+++ b/src/KOKKOS/pair_table_rx_kokkos.cpp
@@ -467,9 +467,9 @@ compute_item(
       auto fpair = factor_lj * compute_fpair<DeviceType,TABSTYLE>(
           rsq,itype,jtype,d_table_const);
 
-      if (isite1 == isite2) fpair *= sqrt(mixWtSite1old_i * mixWtSite2old_j);
-      else fpair *= (sqrt(mixWtSite1old_i * mixWtSite2old_j) +
-                     sqrt(mixWtSite2old_i * mixWtSite1old_j));
+      if (isite1 == isite2) fpair *= Kokkos::Experimental::sqrt(mixWtSite1old_i * mixWtSite2old_j);
+      else fpair *= (Kokkos::Experimental::sqrt(mixWtSite1old_i * mixWtSite2old_j) +
+                     Kokkos::Experimental::sqrt(mixWtSite2old_i * mixWtSite1old_j));
 
       fx_i += delx*fpair;
       fy_i += dely*fpair;
@@ -488,13 +488,13 @@ compute_item(
 
       double evdwlOld;
       if (isite1 == isite2) {
-        evdwlOld = sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwl;
-        evdwl = sqrt(mixWtSite1_i*mixWtSite2_j)*evdwl;
+        evdwlOld = Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j)*evdwl;
+        evdwl = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*evdwl;
       } else {
-        evdwlOld = (sqrt(mixWtSite1old_i*mixWtSite2old_j) +
-                    sqrt(mixWtSite2old_i*mixWtSite1old_j))*evdwl;
-        evdwl = (sqrt(mixWtSite1_i*mixWtSite2_j) +
-                 sqrt(mixWtSite2_i*mixWtSite1_j))*evdwl;
+        evdwlOld = (Kokkos::Experimental::sqrt(mixWtSite1old_i*mixWtSite2old_j) +
+                    Kokkos::Experimental::sqrt(mixWtSite2old_i*mixWtSite1old_j))*evdwl;
+        evdwl = (Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j) +
+                 Kokkos::Experimental::sqrt(mixWtSite2_i*mixWtSite1_j))*evdwl;
       }
       evdwlOld *= factor_lj;
       evdwl *= factor_lj;
@@ -1233,8 +1233,8 @@ double PairTableRXKokkos<DeviceType>::single(int i, int j, int itype, int jtype,
     fforce = factor_lj * value;
   }
 
-  if (isite1 == isite2) fforce = sqrt(mixWtSite1_i*mixWtSite2_j)*fforce;
-  else fforce = (sqrt(mixWtSite1_i*mixWtSite2_j) + sqrt(mixWtSite2_i*mixWtSite1_j))*fforce;
+  if (isite1 == isite2) fforce = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*fforce;
+  else fforce = (Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j) + Kokkos::Experimental::sqrt(mixWtSite2_i*mixWtSite1_j))*fforce;
 
   if (tabstyle == LOOKUP)
     phi = tb->e[itable];
@@ -1244,8 +1244,8 @@ double PairTableRXKokkos<DeviceType>::single(int i, int j, int itype, int jtype,
     phi = a * tb->e[itable] + b * tb->e[itable+1] +
       ((a*a*a-a)*tb->e2[itable] + (b*b*b-b)*tb->e2[itable+1]) * tb->deltasq6;
 
-  if (isite1 == isite2) phi = sqrt(mixWtSite1_i*mixWtSite2_j)*phi;
-  else phi = (sqrt(mixWtSite1_i*mixWtSite2_j) + sqrt(mixWtSite2_i*mixWtSite1_j))*phi;
+  if (isite1 == isite2) phi = Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j)*phi;
+  else phi = (Kokkos::Experimental::sqrt(mixWtSite1_i*mixWtSite2_j) + Kokkos::Experimental::sqrt(mixWtSite2_i*mixWtSite1_j))*phi;
 
   return factor_lj*phi;
 }

--- a/src/KOKKOS/pair_tersoff_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_kokkos.cpp
@@ -374,10 +374,10 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
 
     if (rsq > cutsq) continue;
 
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
     const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
+    const F_FLOAT tmp_exp = Kokkos::Experimental::exp(-paramskk(itype,jtype,jtype).lam1 * r);
     const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
                           (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / r;
     const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
@@ -410,7 +410,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
 
     F_FLOAT bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    const F_FLOAT rij = sqrt(rsq1);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq1);
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
@@ -425,7 +425,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
       const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      const F_FLOAT rik = sqrt(rsq2);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
@@ -466,7 +466,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeHalf<NEIGHFL
       const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      const F_FLOAT rik = sqrt(rsq2);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
@@ -543,10 +543,10 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
 
     if (rsq > cutsq) continue;
 
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
     const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
+    const F_FLOAT tmp_exp = Kokkos::Experimental::exp(-paramskk(itype,jtype,jtype).lam1 * r);
     const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
                           (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / r;
     const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
@@ -578,7 +578,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
+    rij = Kokkos::Experimental::sqrt(rsq1);
 
     for (kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
@@ -593,7 +593,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
       cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
@@ -631,7 +631,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullA<NEIGHF
       cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
@@ -700,7 +700,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
+    rij = Kokkos::Experimental::sqrt(rsq1);
 
     j_jnum = d_numneigh_short[j];
 
@@ -717,7 +717,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
       cutsq2 = paramskk(jtype,itype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(jtype,itype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
 
     }
@@ -757,7 +757,7 @@ void PairTersoffKokkos<DeviceType>::operator()(TagPairTersoffComputeFullB<NEIGHF
       cutsq2 = paramskk(jtype,itype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthbj(jtype,itype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fj,fk);
       f_x += fj[0];
@@ -805,7 +805,7 @@ double PairTersoffKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
 
   if (r < ters_R-ters_D) return 1.0;
   if (r > ters_R+ters_D) return 0.0;
-  return 0.5*(1.0 - sin(MY_PI2*(r - ters_R)/ters_D));
+  return 0.5*(1.0 - Kokkos::Experimental::sin(MY_PI2*(r - ters_R)/ters_D));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -820,7 +820,7 @@ double PairTersoffKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
 
   if (r < ters_R-ters_D) return 0.0;
   if (r > ters_R+ters_D) return 0.0;
-  return -(MY_PI4/ters_D) * cos(MY_PI2*(r - ters_R)/ters_D);
+  return -(MY_PI4/ters_D) * Kokkos::Experimental::cos(MY_PI2*(r - ters_R)/ters_D);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -836,12 +836,12 @@ double PairTersoffKokkos<DeviceType>::bondorder(const int &i, const int &j, cons
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
   const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) arg = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) arg = param*param*param;//Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else arg = param;
 
   if (arg > 69.0776) ex_delr = 1.e30;
   else if (arg < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(arg);
+  else ex_delr = Kokkos::Experimental::exp(arg);
 
   return ters_fc_k(i,j,k,rik) * ters_gijk(i,j,k,costheta) * ex_delr;
 }
@@ -883,7 +883,7 @@ double PairTersoffKokkos<DeviceType>::ters_fa_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
   if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return -paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r)
+  return -paramskk(i,j,k).bigb * Kokkos::Experimental::exp(-paramskk(i,j,k).lam2 * r)
           * ters_fc_k(i,j,k,r);
 }
 
@@ -895,7 +895,7 @@ double PairTersoffKokkos<DeviceType>::ters_dfa(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
   if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r) *
+  return paramskk(i,j,k).bigb * Kokkos::Experimental::exp(-paramskk(i,j,k).lam2 * r) *
     (paramskk(i,j,k).lam2 * ters_fc_k(i,j,k,r) - ters_dfc(i,j,k,r));
 }
 
@@ -907,13 +907,13 @@ double PairTersoffKokkos<DeviceType>::ters_bij_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &bo) const
 {
   const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return 1.0/sqrt(tmp);
+  if (tmp > paramskk(i,j,k).c1) return 1.0/Kokkos::Experimental::sqrt(tmp);
   if (tmp > paramskk(i,j,k).c2)
-    return (1.0 - pow(tmp,-paramskk(i,j,k).powern) / (2.0*paramskk(i,j,k).powern))/sqrt(tmp);
+    return (1.0 - Kokkos::Experimental::pow(tmp,-paramskk(i,j,k).powern) / (2.0*paramskk(i,j,k).powern))/Kokkos::Experimental::sqrt(tmp);
   if (tmp < paramskk(i,j,k).c4) return 1.0;
   if (tmp < paramskk(i,j,k).c3)
-    return 1.0 - pow(tmp,paramskk(i,j,k).powern)/(2.0*paramskk(i,j,k).powern);
-  return pow(1.0 + pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern));
+    return 1.0 - Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern)/(2.0*paramskk(i,j,k).powern);
+  return Kokkos::Experimental::pow(1.0 + Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -924,17 +924,17 @@ double PairTersoffKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
                 const int &k, const F_FLOAT &bo) const
 {
   const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return paramskk(i,j,k).beta * -0.5/sqrt(tmp*tmp);//*pow(tmp,-1.5);
+  if (tmp > paramskk(i,j,k).c1) return paramskk(i,j,k).beta * -0.5/Kokkos::Experimental::sqrt(tmp*tmp);//*Kokkos::Experimental::pow(tmp,-1.5);
   if (tmp > paramskk(i,j,k).c2)
-    return paramskk(i,j,k).beta * (-0.5/sqrt(tmp*tmp) * //*pow(tmp,-1.5) *
+    return paramskk(i,j,k).beta * (-0.5/Kokkos::Experimental::sqrt(tmp*tmp) * //*Kokkos::Experimental::pow(tmp,-1.5) *
            (1.0 - 0.5*(1.0 +  1.0/(2.0*paramskk(i,j,k).powern)) *
-           pow(tmp,-paramskk(i,j,k).powern)));
+           Kokkos::Experimental::pow(tmp,-paramskk(i,j,k).powern)));
   if (tmp < paramskk(i,j,k).c4) return 0.0;
   if (tmp < paramskk(i,j,k).c3)
-    return -0.5*paramskk(i,j,k).beta * pow(tmp,paramskk(i,j,k).powern-1.0);
+    return -0.5*paramskk(i,j,k).beta * Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern-1.0);
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
-  return -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern)))*tmp_n / bo;
+  const F_FLOAT tmp_n = Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern);
+  return -0.5 * Kokkos::Experimental::pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern)))*tmp_n / bo;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -955,11 +955,11 @@ void PairTersoffKokkos<DeviceType>::ters_dthb(
   delrij[0] = dx1; delrij[1] = dy1; delrij[2] = dz1;
   delrik[0] = dx2; delrik[1] = dy2; delrik[2] = dz2;
 
-  //rij = sqrt(rsq1);
+  //rij = Kokkos::Experimental::sqrt(rsq1);
   rijinv = 1.0/rij;
   vec3_scale(rijinv,delrij,rij_hat);
 
-  //rik = sqrt(rsq2);
+  //rik = Kokkos::Experimental::sqrt(rsq2);
   rikinv = 1.0/rik;
   vec3_scale(rikinv,delrik,rik_hat);
 
@@ -970,15 +970,15 @@ void PairTersoffKokkos<DeviceType>::ters_dthb(
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
   const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = param;
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1039,15 +1039,15 @@ void PairTersoffKokkos<DeviceType>::ters_dthbj(
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
   const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = param;//paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1101,15 +1101,15 @@ void PairTersoffKokkos<DeviceType>::ters_dthbk(
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
   const F_FLOAT param = paramskk(i,j,k).lam3 * (rij-rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = param*param*param;//Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = param;//paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*param*param*paramskk(i,j,k).lam3*ex_delr;//Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);

--- a/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_mod_kokkos.cpp
@@ -374,10 +374,10 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
 
     if (rsq > cutsq) continue;
 
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
     const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
+    const F_FLOAT tmp_exp = Kokkos::Experimental::exp(-paramskk(itype,jtype,jtype).lam1 * r);
     const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
                           (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / r;
     const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
@@ -410,7 +410,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
 
     F_FLOAT bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    const F_FLOAT rij = sqrt(rsq1);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq1);
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
@@ -425,7 +425,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
       const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      const F_FLOAT rik = sqrt(rsq2);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
@@ -466,7 +466,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeHalf<N
       const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      const F_FLOAT rik = sqrt(rsq2);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
@@ -543,10 +543,10 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullA<
 
     if (rsq > cutsq) continue;
 
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
     const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
+    const F_FLOAT tmp_exp = Kokkos::Experimental::exp(-paramskk(itype,jtype,jtype).lam1 * r);
     const F_FLOAT frep = -paramskk(itype,jtype,jtype).biga * tmp_exp *
                           (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1) / r;
     const F_FLOAT eng = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
@@ -578,7 +578,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullA<
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
+    rij = Kokkos::Experimental::sqrt(rsq1);
 
     for (kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
@@ -593,7 +593,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullA<
       cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
@@ -631,7 +631,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullA<
       cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
@@ -700,7 +700,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullB<
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
+    rij = Kokkos::Experimental::sqrt(rsq1);
 
     j_jnum = d_numneigh_short[j];
 
@@ -717,7 +717,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullB<
       cutsq2 = paramskk(jtype,itype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(jtype,itype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
 
     }
@@ -757,7 +757,7 @@ void PairTersoffMODKokkos<DeviceType>::operator()(TagPairTersoffMODComputeFullB<
       cutsq2 = paramskk(jtype,itype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthbj(jtype,itype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fj,fk);
       f_x += fj[0];
@@ -805,8 +805,8 @@ double PairTersoffMODKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
 
   if (r < ters_R-ters_D) return 1.0;
   if (r > ters_R+ters_D) return 0.0;
-  return 0.5*(1.0 - 1.125*sin(MY_PI2*(r - ters_R)/ters_D) -
-              0.125*sin(3.0*MY_PI2*(r - ters_R)/ters_D));
+  return 0.5*(1.0 - 1.125*Kokkos::Experimental::sin(MY_PI2*(r - ters_R)/ters_D) -
+              0.125*Kokkos::Experimental::sin(3.0*MY_PI2*(r - ters_R)/ters_D));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -821,8 +821,8 @@ double PairTersoffMODKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
 
   if (r < ters_R-ters_D) return 0.0;
   if (r > ters_R+ters_D) return 0.0;
-  return -(0.375*MY_PI4/ters_D) * (3.0*cos(MY_PI2*(r - ters_R)/ters_D) +
-                                   cos(3.0*MY_PI2*(r - ters_R)/ters_D));
+  return -(0.375*MY_PI4/ters_D) * (3.0*Kokkos::Experimental::cos(MY_PI2*(r - ters_R)/ters_D) +
+                                   Kokkos::Experimental::cos(3.0*MY_PI2*(r - ters_R)/ters_D));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -837,12 +837,12 @@ double PairTersoffMODKokkos<DeviceType>::bondorder(const int &i, const int &j, c
 
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
-  if (int(paramskk(i,j,k).powerm) == 3) arg = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) arg = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else arg = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (arg > 69.0776) ex_delr = 1.e30;
   else if (arg < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(arg);
+  else ex_delr = Kokkos::Experimental::exp(arg);
 
   return ters_fc_k(i,j,k,rik) * ters_gijk(i,j,k,costheta) * ex_delr;
 }
@@ -862,7 +862,7 @@ double PairTersoffMODKokkos<DeviceType>::
   const F_FLOAT tmp_h = (paramskk(i,j,k).h - cos)*(paramskk(i,j,k).h - cos);
 
   return ters_c1 + (ters_c2*tmp_h/(ters_c3 + tmp_h)) *
-      (1.0 + ters_c4*exp(-ters_c5*tmp_h));
+      (1.0 + ters_c4*Kokkos::Experimental::exp(-ters_c5*tmp_h));
 
 }
 
@@ -879,7 +879,7 @@ double PairTersoffMODKokkos<DeviceType>::
   const F_FLOAT ters_c5 = paramskk(i,j,k).c5;
   const F_FLOAT tmp_h = (paramskk(i,j,k).h - cos)*(paramskk(i,j,k).h - cos);
   const F_FLOAT g1 = (paramskk(i,j,k).h - cos)/(ters_c3 + tmp_h);
-  const F_FLOAT g2 = exp(-ters_c5*tmp_h);
+  const F_FLOAT g2 = Kokkos::Experimental::exp(-ters_c5*tmp_h);
 
   return -2.0*ters_c2*g1*((1 + ters_c4*g2)*(1 + g1*(cos - paramskk(i,j,k).h)) -
                             tmp_h*ters_c4*ters_c5*g2);
@@ -893,7 +893,7 @@ double PairTersoffMODKokkos<DeviceType>::ters_fa_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
   if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return -paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r)
+  return -paramskk(i,j,k).bigb * Kokkos::Experimental::exp(-paramskk(i,j,k).lam2 * r)
           * ters_fc_k(i,j,k,r);
 }
 
@@ -905,7 +905,7 @@ double PairTersoffMODKokkos<DeviceType>::ters_dfa(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
   if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r) *
+  return paramskk(i,j,k).bigb * Kokkos::Experimental::exp(-paramskk(i,j,k).lam2 * r) *
     (paramskk(i,j,k).lam2 * ters_fc_k(i,j,k,r) - ters_dfc(i,j,k,r));
 }
 
@@ -918,10 +918,10 @@ double PairTersoffMODKokkos<DeviceType>::ters_bij_k(const int &i, const int &j,
 {
   const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
   if (tmp > paramskk(i,j,k).ca1)
-    return pow(tmp, -paramskk(i,j,k).powern/(2.0*paramskk(i,j,k).powern_del));
+    return Kokkos::Experimental::pow(tmp, -paramskk(i,j,k).powern/(2.0*paramskk(i,j,k).powern_del));
   if (tmp < paramskk(i,j,k).ca4)
     return 1.0;
-  return pow(1.0 + pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern_del));
+  return Kokkos::Experimental::pow(1.0 + Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern_del));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -934,13 +934,13 @@ double PairTersoffMODKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
   const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
   if (tmp > paramskk(i,j,k).ca1)
     return -0.5*(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)*
-          pow(tmp,-0.5*(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)) / bo;
+          Kokkos::Experimental::pow(tmp,-0.5*(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)) / bo;
   if (tmp < paramskk(i,j,k).ca4)
     return 0.0;
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
+  const F_FLOAT tmp_n = Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern);
   return -0.5 *(paramskk(i,j,k).powern/paramskk(i,j,k).powern_del)*
-          pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern_del)))*tmp_n / bo;
+          Kokkos::Experimental::pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern_del)))*tmp_n / bo;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -961,11 +961,11 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthb(
   delrij[0] = dx1; delrij[1] = dy1; delrij[2] = dz1;
   delrik[0] = dx2; delrik[1] = dy2; delrik[2] = dz2;
 
-  //rij = sqrt(rsq1);
+  //rij = Kokkos::Experimental::sqrt(rsq1);
   rijinv = 1.0/rij;
   vec3_scale(rijinv,delrij,rij_hat);
 
-  //rik = sqrt(rsq2);
+  //rik = Kokkos::Experimental::sqrt(rsq2);
   rikinv = 1.0/rik;
   vec3_scale(rikinv,delrik,rik_hat);
 
@@ -975,15 +975,15 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthb(
 
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1043,15 +1043,15 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbj(
 
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1104,15 +1104,15 @@ void PairTersoffMODKokkos<DeviceType>::ters_dthbk(
 
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);

--- a/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_tersoff_zbl_kokkos.cpp
@@ -390,28 +390,28 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
 
     // Tersoff repulsive portion
 
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
     const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
+    const F_FLOAT tmp_exp = Kokkos::Experimental::exp(-paramskk(itype,jtype,jtype).lam1 * r);
     const F_FLOAT frep_t = paramskk(itype,jtype,jtype).biga * tmp_exp *
                           (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1);
     const F_FLOAT eng_t = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
 
     // ZBL repulsive portion
 
-    const F_FLOAT esq = pow(global_e,2.0);
+    const F_FLOAT esq = Kokkos::Experimental::pow(global_e,2.0);
     const F_FLOAT a_ij = (0.8854*global_a_0) /
-            (pow(paramskk(itype,jtype,jtype).Z_i,0.23) + pow(paramskk(itype,jtype,jtype).Z_j,0.23));
+            (Kokkos::Experimental::pow(paramskk(itype,jtype,jtype).Z_i,0.23) + Kokkos::Experimental::pow(paramskk(itype,jtype,jtype).Z_j,0.23));
     const F_FLOAT premult = (paramskk(itype,jtype,jtype).Z_i * paramskk(itype,jtype,jtype).Z_j * esq)/
             (4.0*MY_PI*global_epsilon_0);
     const F_FLOAT r_ov_a = r/a_ij;
-    const F_FLOAT phi = 0.1818*exp(-3.2*r_ov_a) + 0.5099*exp(-0.9423*r_ov_a) +
-            0.2802*exp(-0.4029*r_ov_a) + 0.02817*exp(-0.2016*r_ov_a);
-    const F_FLOAT dphi = (1.0/a_ij) * (-3.2*0.1818*exp(-3.2*r_ov_a) -
-                              0.9423*0.5099*exp(-0.9423*r_ov_a) -
-                              0.4029*0.2802*exp(-0.4029*r_ov_a) -
-                              0.2016*0.02817*exp(-0.2016*r_ov_a));
+    const F_FLOAT phi = 0.1818*Kokkos::Experimental::exp(-3.2*r_ov_a) + 0.5099*Kokkos::Experimental::exp(-0.9423*r_ov_a) +
+            0.2802*Kokkos::Experimental::exp(-0.4029*r_ov_a) + 0.02817*Kokkos::Experimental::exp(-0.2016*r_ov_a);
+    const F_FLOAT dphi = (1.0/a_ij) * (-3.2*0.1818*Kokkos::Experimental::exp(-3.2*r_ov_a) -
+                              0.9423*0.5099*Kokkos::Experimental::exp(-0.9423*r_ov_a) -
+                              0.4029*0.2802*Kokkos::Experimental::exp(-0.4029*r_ov_a) -
+                              0.2016*0.02817*Kokkos::Experimental::exp(-0.2016*r_ov_a));
     const F_FLOAT frep_z = premult*-phi/rsq + premult*dphi/r;
     const F_FLOAT eng_z = premult*(1.0/r)*phi;
 
@@ -454,7 +454,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
 
     F_FLOAT bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    const F_FLOAT rij = sqrt(rsq1);
+    const F_FLOAT rij = Kokkos::Experimental::sqrt(rsq1);
 
     for (int kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
@@ -469,7 +469,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
       const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      const F_FLOAT rik = sqrt(rsq2);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
@@ -510,7 +510,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeHalf<N
       const F_FLOAT cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      const F_FLOAT rik = sqrt(rsq2);
+      const F_FLOAT rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
@@ -589,28 +589,28 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullA<
 
     // Tersoff repulsive portion
 
-    const F_FLOAT r = sqrt(rsq);
+    const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
     const F_FLOAT tmp_fce = ters_fc_k(itype,jtype,jtype,r);
     const F_FLOAT tmp_fcd = ters_dfc(itype,jtype,jtype,r);
-    const F_FLOAT tmp_exp = exp(-paramskk(itype,jtype,jtype).lam1 * r);
+    const F_FLOAT tmp_exp = Kokkos::Experimental::exp(-paramskk(itype,jtype,jtype).lam1 * r);
     const F_FLOAT frep_t = paramskk(itype,jtype,jtype).biga * tmp_exp *
                           (tmp_fcd - tmp_fce*paramskk(itype,jtype,jtype).lam1);
     const F_FLOAT eng_t = tmp_fce * paramskk(itype,jtype,jtype).biga * tmp_exp;
 
     // ZBL repulsive portion
 
-    const F_FLOAT esq = pow(global_e,2.0);
+    const F_FLOAT esq = Kokkos::Experimental::pow(global_e,2.0);
     const F_FLOAT a_ij = (0.8854*global_a_0) /
-            (pow(paramskk(itype,jtype,jtype).Z_i,0.23) + pow(paramskk(itype,jtype,jtype).Z_j,0.23));
+            (Kokkos::Experimental::pow(paramskk(itype,jtype,jtype).Z_i,0.23) + Kokkos::Experimental::pow(paramskk(itype,jtype,jtype).Z_j,0.23));
     const F_FLOAT premult = (paramskk(itype,jtype,jtype).Z_i * paramskk(itype,jtype,jtype).Z_j * esq)/
             (4.0*MY_PI*global_epsilon_0);
     const F_FLOAT r_ov_a = r/a_ij;
-    const F_FLOAT phi = 0.1818*exp(-3.2*r_ov_a) + 0.5099*exp(-0.9423*r_ov_a) +
-            0.2802*exp(-0.4029*r_ov_a) + 0.02817*exp(-0.2016*r_ov_a);
-    const F_FLOAT dphi = (1.0/a_ij) * (-3.2*0.1818*exp(-3.2*r_ov_a) -
-                              0.9423*0.5099*exp(-0.9423*r_ov_a) -
-                              0.4029*0.2802*exp(-0.4029*r_ov_a) -
-                              0.2016*0.02817*exp(-0.2016*r_ov_a));
+    const F_FLOAT phi = 0.1818*Kokkos::Experimental::exp(-3.2*r_ov_a) + 0.5099*Kokkos::Experimental::exp(-0.9423*r_ov_a) +
+            0.2802*Kokkos::Experimental::exp(-0.4029*r_ov_a) + 0.02817*Kokkos::Experimental::exp(-0.2016*r_ov_a);
+    const F_FLOAT dphi = (1.0/a_ij) * (-3.2*0.1818*Kokkos::Experimental::exp(-3.2*r_ov_a) -
+                              0.9423*0.5099*Kokkos::Experimental::exp(-0.9423*r_ov_a) -
+                              0.4029*0.2802*Kokkos::Experimental::exp(-0.4029*r_ov_a) -
+                              0.2016*0.02817*Kokkos::Experimental::exp(-0.2016*r_ov_a));
     const F_FLOAT frep_z = premult*-phi/rsq + premult*dphi/r;
     const F_FLOAT eng_z = premult*(1.0/r)*phi;
 
@@ -652,7 +652,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullA<
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
+    rij = Kokkos::Experimental::sqrt(rsq1);
 
     for (kk = 0; kk < jnum; kk++) {
       if (jj == kk) continue;
@@ -667,7 +667,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullA<
       cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(itype,jtype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
     }
 
@@ -705,7 +705,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullA<
       cutsq2 = paramskk(itype,jtype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthb(itype,jtype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fi,fj,fk);
 
@@ -774,7 +774,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullB<
 
     bo_ij = 0.0;
     if (rsq1 > cutsq1) continue;
-    rij = sqrt(rsq1);
+    rij = Kokkos::Experimental::sqrt(rsq1);
 
     j_jnum = d_numneigh_short[j];
 
@@ -791,7 +791,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullB<
       cutsq2 = paramskk(jtype,itype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       bo_ij += bondorder(jtype,itype,ktype,rij,delx1,dely1,delz1,rik,delx2,dely2,delz2);
 
     }
@@ -831,7 +831,7 @@ void PairTersoffZBLKokkos<DeviceType>::operator()(TagPairTersoffZBLComputeFullB<
       cutsq2 = paramskk(jtype,itype,ktype).cutsq;
 
       if (rsq2 > cutsq2) continue;
-      rik = sqrt(rsq2);
+      rik = Kokkos::Experimental::sqrt(rsq2);
       ters_dthbj(jtype,itype,ktype,prefactor,rij,delx1,dely1,delz1,
                 rik,delx2,dely2,delz2,fj,fk);
       f_x += fj[0];
@@ -879,7 +879,7 @@ double PairTersoffZBLKokkos<DeviceType>::ters_fc_k(const int &i, const int &j,
 
   if (r < ters_R-ters_D) return 1.0;
   if (r > ters_R+ters_D) return 0.0;
-  return 0.5*(1.0 - sin(MY_PI2*(r - ters_R)/ters_D));
+  return 0.5*(1.0 - Kokkos::Experimental::sin(MY_PI2*(r - ters_R)/ters_D));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -894,7 +894,7 @@ double PairTersoffZBLKokkos<DeviceType>::ters_dfc(const int &i, const int &j,
 
   if (r < ters_R-ters_D) return 0.0;
   if (r > ters_R+ters_D) return 0.0;
-  return -(MY_PI4/ters_D) * cos(MY_PI2*(r - ters_R)/ters_D);
+  return -(MY_PI4/ters_D) * Kokkos::Experimental::cos(MY_PI2*(r - ters_R)/ters_D);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -909,12 +909,12 @@ double PairTersoffZBLKokkos<DeviceType>::bondorder(const int &i, const int &j, c
 
   const F_FLOAT costheta = (dx1*dx2 + dy1*dy2 + dz1*dz2)/(rij*rik);
 
-  if (int(paramskk(i,j,k).powerm) == 3) arg = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) arg = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else arg = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (arg > 69.0776) ex_delr = 1.e30;
   else if (arg < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(arg);
+  else ex_delr = Kokkos::Experimental::exp(arg);
 
   return ters_fc_k(i,j,k,rik) * ters_gijk(i,j,k,costheta) * ex_delr;
 }
@@ -957,7 +957,7 @@ double PairTersoffZBLKokkos<DeviceType>::ters_fa_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
   if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return -paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r)
+  return -paramskk(i,j,k).bigb * Kokkos::Experimental::exp(-paramskk(i,j,k).lam2 * r)
           * ters_fc_k(i,j,k,r) * fermi_k(i,j,k,r);
 }
 
@@ -969,7 +969,7 @@ double PairTersoffZBLKokkos<DeviceType>::ters_dfa(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
   if (r > paramskk(i,j,k).bigr + paramskk(i,j,k).bigd) return 0.0;
-  return paramskk(i,j,k).bigb * exp(-paramskk(i,j,k).lam2 * r) *
+  return paramskk(i,j,k).bigb * Kokkos::Experimental::exp(-paramskk(i,j,k).lam2 * r) *
     (paramskk(i,j,k).lam2 * ters_fc_k(i,j,k,r) * fermi_k(i,j,k,r) -
      ters_dfc(i,j,k,r) * fermi_k(i,j,k,r) - ters_fc_k(i,j,k,r) *
      fermi_d_k(i,j,k,r));
@@ -983,13 +983,13 @@ double PairTersoffZBLKokkos<DeviceType>::ters_bij_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &bo) const
 {
   const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return 1.0/sqrt(tmp);
+  if (tmp > paramskk(i,j,k).c1) return 1.0/Kokkos::Experimental::sqrt(tmp);
   if (tmp > paramskk(i,j,k).c2)
-    return (1.0 - pow(tmp,-paramskk(i,j,k).powern) / (2.0*paramskk(i,j,k).powern))/sqrt(tmp);
+    return (1.0 - Kokkos::Experimental::pow(tmp,-paramskk(i,j,k).powern) / (2.0*paramskk(i,j,k).powern))/Kokkos::Experimental::sqrt(tmp);
   if (tmp < paramskk(i,j,k).c4) return 1.0;
   if (tmp < paramskk(i,j,k).c3)
-    return 1.0 - pow(tmp,paramskk(i,j,k).powern)/(2.0*paramskk(i,j,k).powern);
-  return pow(1.0 + pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern));
+    return 1.0 - Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern)/(2.0*paramskk(i,j,k).powern);
+  return Kokkos::Experimental::pow(1.0 + Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern), -1.0/(2.0*paramskk(i,j,k).powern));
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1000,17 +1000,17 @@ double PairTersoffZBLKokkos<DeviceType>::ters_dbij(const int &i, const int &j,
                 const int &k, const F_FLOAT &bo) const
 {
   const F_FLOAT tmp = paramskk(i,j,k).beta * bo;
-  if (tmp > paramskk(i,j,k).c1) return paramskk(i,j,k).beta * -0.5*pow(tmp,-1.5);
+  if (tmp > paramskk(i,j,k).c1) return paramskk(i,j,k).beta * -0.5*Kokkos::Experimental::pow(tmp,-1.5);
   if (tmp > paramskk(i,j,k).c2)
-    return paramskk(i,j,k).beta * (-0.5*pow(tmp,-1.5) *
+    return paramskk(i,j,k).beta * (-0.5*Kokkos::Experimental::pow(tmp,-1.5) *
            (1.0 - 0.5*(1.0 +  1.0/(2.0*paramskk(i,j,k).powern)) *
-           pow(tmp,-paramskk(i,j,k).powern)));
+           Kokkos::Experimental::pow(tmp,-paramskk(i,j,k).powern)));
   if (tmp < paramskk(i,j,k).c4) return 0.0;
   if (tmp < paramskk(i,j,k).c3)
-    return -0.5*paramskk(i,j,k).beta * pow(tmp,paramskk(i,j,k).powern-1.0);
+    return -0.5*paramskk(i,j,k).beta * Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern-1.0);
 
-  const F_FLOAT tmp_n = pow(tmp,paramskk(i,j,k).powern);
-  return -0.5 * pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern)))*tmp_n / bo;
+  const F_FLOAT tmp_n = Kokkos::Experimental::pow(tmp,paramskk(i,j,k).powern);
+  return -0.5 * Kokkos::Experimental::pow(1.0+tmp_n, -1.0-(1.0/(2.0*paramskk(i,j,k).powern)))*tmp_n / bo;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1031,11 +1031,11 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthb(
   delrij[0] = dx1; delrij[1] = dy1; delrij[2] = dz1;
   delrik[0] = dx2; delrik[1] = dy2; delrik[2] = dz2;
 
-  //rij = sqrt(rsq1);
+  //rij = Kokkos::Experimental::sqrt(rsq1);
   rijinv = 1.0/rij;
   vec3_scale(rijinv,delrij,rij_hat);
 
-  //rik = sqrt(rsq2);
+  //rik = Kokkos::Experimental::sqrt(rsq2);
   rikinv = 1.0/rik;
   vec3_scale(rikinv,delrik,rik_hat);
 
@@ -1045,15 +1045,15 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthb(
 
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1113,15 +1113,15 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbj(
 
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1174,15 +1174,15 @@ void PairTersoffZBLKokkos<DeviceType>::ters_dthbk(
 
   fc = ters_fc_k(i,j,k,rik);
   dfc = ters_dfc(i,j,k,rik);
-  if (int(paramskk(i,j,k).powerm) == 3) tmp = pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
+  if (int(paramskk(i,j,k).powerm) == 3) tmp = Kokkos::Experimental::pow(paramskk(i,j,k).lam3 * (rij-rik),3.0);
   else tmp = paramskk(i,j,k).lam3 * (rij-rik);
 
   if (tmp > 69.0776) ex_delr = 1.e30;
   else if (tmp < -69.0776) ex_delr = 0.0;
-  else ex_delr = exp(tmp);
+  else ex_delr = Kokkos::Experimental::exp(tmp);
 
   if (int(paramskk(i,j,k).powerm) == 3)
-    dex_delr = 3.0*pow(paramskk(i,j,k).lam3,3.0) * pow(rij-rik,2.0)*ex_delr;
+    dex_delr = 3.0*Kokkos::Experimental::pow(paramskk(i,j,k).lam3,3.0) * Kokkos::Experimental::pow(rij-rik,2.0)*ex_delr;
   else dex_delr = paramskk(i,j,k).lam3 * ex_delr;
 
   cos = vec3_dot(rij_hat,rik_hat);
@@ -1210,7 +1210,7 @@ KOKKOS_INLINE_FUNCTION
 double PairTersoffZBLKokkos<DeviceType>::fermi_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
-  return 1.0 / (1.0 + exp(-paramskk(i,j,k).ZBLexpscale *
+  return 1.0 / (1.0 + Kokkos::Experimental::exp(-paramskk(i,j,k).ZBLexpscale *
                           (r - paramskk(i,j,k).ZBLcut)));
 }
 
@@ -1221,9 +1221,9 @@ KOKKOS_INLINE_FUNCTION
 double PairTersoffZBLKokkos<DeviceType>::fermi_d_k(const int &i, const int &j,
                 const int &k, const F_FLOAT &r) const
 {
-  return paramskk(i,j,k).ZBLexpscale * exp(-paramskk(i,j,k).ZBLexpscale *
+  return paramskk(i,j,k).ZBLexpscale * Kokkos::Experimental::exp(-paramskk(i,j,k).ZBLexpscale *
          (r - paramskk(i,j,k).ZBLcut)) /
-         pow(1.0 + exp(-paramskk(i,j,k).ZBLexpscale *
+         Kokkos::Experimental::pow(1.0 + Kokkos::Experimental::exp(-paramskk(i,j,k).ZBLexpscale *
          (r - paramskk(i,j,k).ZBLcut)),2.0);
 }
 

--- a/src/KOKKOS/pair_vashishta_kokkos.cpp
+++ b/src/KOKKOS/pair_vashishta_kokkos.cpp
@@ -645,15 +645,15 @@ void PairVashishtaKokkos<DeviceType>::twobody(const Param& param, const F_FLOAT&
                      const int& eflag, F_FLOAT& eng) const
 {
   F_FLOAT r,rinvsq,r4inv,r6inv,reta,lam1r,lam4r,vc2,vc3;
-  r = sqrt(rsq);
+  r = Kokkos::Experimental::sqrt(rsq);
   rinvsq = 1.0/rsq;
   r4inv = rinvsq*rinvsq;
   r6inv = rinvsq*r4inv;
-  reta = pow(r,-param.eta);
+  reta = Kokkos::Experimental::pow(r,-param.eta);
   lam1r = r*param.lam1inv;
   lam4r = r*param.lam4inv;
-  vc2 = param.zizj * exp(-lam1r)/r;
-  vc3 = param.mbigd * r4inv*exp(-lam4r);
+  vc2 = param.zizj * Kokkos::Experimental::exp(-lam1r)/r;
+  vc3 = param.mbigd * r4inv*Kokkos::Experimental::exp(-lam4r);
 
   fforce = (param.dvrc*r
       - (4.0*vc3 + lam4r*vc3+param.big6w*r6inv
@@ -677,19 +677,19 @@ void PairVashishtaKokkos<DeviceType>::threebody(const Param& paramij, const Para
   F_FLOAT rinv12,cs,delcs,delcssq,facexp,facrad,frad1,frad2,pcsinv,pcsinvsq,pcs;
   F_FLOAT facang,facang12,csfacang,csfac1,csfac2;
 
-  r1 = sqrt(rsq1);
+  r1 = Kokkos::Experimental::sqrt(rsq1);
   rinvsq1 = 1.0/rsq1;
   rainv1 = 1.0/(r1 - paramij.r0);
   gsrainv1 = paramij.gamma * rainv1;
   gsrainvsq1 = gsrainv1*rainv1/r1;
-  expgsrainv1 = exp(gsrainv1);
+  expgsrainv1 = Kokkos::Experimental::exp(gsrainv1);
 
-  r2 = sqrt(rsq2);
+  r2 = Kokkos::Experimental::sqrt(rsq2);
   rinvsq2 = 1.0/rsq2;
   rainv2 = 1.0/(r2 - paramik.r0);
   gsrainv2 = paramik.gamma * rainv2;
   gsrainvsq2 = gsrainv2*rainv2/r2;
-  expgsrainv2 = exp(gsrainv2);
+  expgsrainv2 = Kokkos::Experimental::exp(gsrainv2);
 
   rinv12 = 1.0/(r1*r2);
   cs = (delr1[0]*delr2[0] + delr1[1]*delr2[1] + delr1[2]*delr2[2]) * rinv12;
@@ -734,17 +734,17 @@ void PairVashishtaKokkos<DeviceType>::threebodyj(const Param& paramij, const Par
   F_FLOAT rinv12,cs,delcs,delcssq,facexp,facrad,frad1,pcsinv,pcsinvsq,pcs;
   F_FLOAT facang,facang12,csfacang,csfac1;
 
-  r1 = sqrt(rsq1);
+  r1 = Kokkos::Experimental::sqrt(rsq1);
   rinvsq1 = 1.0/rsq1;
   rainv1 = 1.0/(r1 - paramij.r0);
   gsrainv1 = paramij.gamma * rainv1;
   gsrainvsq1 = gsrainv1*rainv1/r1;
-  expgsrainv1 = exp(gsrainv1);
+  expgsrainv1 = Kokkos::Experimental::exp(gsrainv1);
 
-  r2 = sqrt(rsq2);
+  r2 = Kokkos::Experimental::sqrt(rsq2);
   rainv2 = 1.0/(r2 - paramik.r0);
   gsrainv2 = paramik.gamma * rainv2;
-  expgsrainv2 = exp(gsrainv2);
+  expgsrainv2 = Kokkos::Experimental::exp(gsrainv2);
 
   rinv12 = 1.0/(r1*r2);
   cs = (delr1[0]*delr2[0] + delr1[1]*delr2[1] + delr1[2]*delr2[2]) * rinv12;

--- a/src/KOKKOS/pair_yukawa_kokkos.cpp
+++ b/src/KOKKOS/pair_yukawa_kokkos.cpp
@@ -233,18 +233,18 @@ compute_fpair(const F_FLOAT& rsq, const int& i, const int&j,
               const int& itype, const int& jtype) const {
   (void) i;
   (void) j;
-  const F_FLOAT rr     = sqrt(rsq);
+  const F_FLOAT rr     = Kokkos::Experimental::sqrt(rsq);
   // Fetch the params either off the stack or from some mapped memory?
   const F_FLOAT aa     = STACKPARAMS ? m_params[itype][jtype].a
                                      : params(itype,jtype).a;
 
-  // U   = a * exp(-kappa*r) / r
-  // f   = (kappa * a * exp(-kappa*r) / r + a*exp(-kappa*r)/r^2)*grad(r)
-  //     = (kappa + 1/r) * (a * exp(-kappa*r) / r)
-  // f/r = (kappa + 1/r) * (a * exp(-kappa*r) / r^2)
+  // U   = a * Kokkos::Experimental::exp(-kappa*r) / r
+  // f   = (kappa * a * Kokkos::Experimental::exp(-kappa*r) / r + a*Kokkos::Experimental::exp(-kappa*r)/r^2)*grad(r)
+  //     = (kappa + 1/r) * (a * Kokkos::Experimental::exp(-kappa*r) / r)
+  // f/r = (kappa + 1/r) * (a * Kokkos::Experimental::exp(-kappa*r) / r^2)
   const F_FLOAT rinv = 1.0 / rr;
   const F_FLOAT rinv2 = rinv*rinv;
-  const F_FLOAT screening = exp(-kappa*rr);
+  const F_FLOAT screening = Kokkos::Experimental::exp(-kappa*rr);
   const F_FLOAT forceyukawa = aa * screening * (kappa + rinv);
   const F_FLOAT fpair = forceyukawa * rinv2;
 
@@ -259,18 +259,18 @@ compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j,
               const int& itype, const int& jtype) const {
   (void) i;
   (void) j;
-  const F_FLOAT rr     = sqrt(rsq);
+  const F_FLOAT rr     = Kokkos::Experimental::sqrt(rsq);
   const F_FLOAT aa     = STACKPARAMS ? m_params[itype][jtype].a
                                      : params(itype,jtype).a;
   const F_FLOAT offset = STACKPARAMS ? m_params[itype][jtype].offset
                                      : params(itype,jtype).offset;
 
-  // U   = a * exp(-kappa*r) / r
-  // f   = (kappa * a * exp(-kappa*r) / r + a*exp(-kappa*r)/r^2)*grad(r)
-  //     = (kappa + 1/r) * (a * exp(-kappa*r) / r)
-  // f/r = (kappa + 1/r) * (a * exp(-kappa*r) / r^2)
+  // U   = a * Kokkos::Experimental::exp(-kappa*r) / r
+  // f   = (kappa * a * Kokkos::Experimental::exp(-kappa*r) / r + a*Kokkos::Experimental::exp(-kappa*r)/r^2)*grad(r)
+  //     = (kappa + 1/r) * (a * Kokkos::Experimental::exp(-kappa*r) / r)
+  // f/r = (kappa + 1/r) * (a * Kokkos::Experimental::exp(-kappa*r) / r^2)
   const F_FLOAT rinv = 1.0 / rr;
-  const F_FLOAT screening = exp(-kappa*rr);
+  const F_FLOAT screening = Kokkos::Experimental::exp(-kappa*rr);
 
   return aa * screening * rinv - offset;
 }

--- a/src/KOKKOS/pair_zbl_kokkos.cpp
+++ b/src/KOKKOS/pair_zbl_kokkos.cpp
@@ -196,7 +196,7 @@ F_FLOAT PairZBLKokkos<DeviceType>::
 compute_fpair(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const {
   (void) i;
   (void) j;
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   F_FLOAT fpair = dzbldr(r, itype, jtype);
 
   if (rsq > cut_innersq) {
@@ -217,7 +217,7 @@ F_FLOAT PairZBLKokkos<DeviceType>::
 compute_evdwl(const F_FLOAT& rsq, const int& i, const int&j, const int& itype, const int& jtype) const {
   (void) i;
   (void) j;
-  const F_FLOAT r = sqrt(rsq);
+  const F_FLOAT r = Kokkos::Experimental::sqrt(rsq);
   F_FLOAT evdwl = e_zbl(r, itype, jtype);
   evdwl += d_sw5(itype,jtype);
   if (rsq > cut_innersq) {
@@ -323,10 +323,10 @@ F_FLOAT PairZBLKokkos<DeviceType>::e_zbl(F_FLOAT r, int i, int j) const {
   const F_FLOAT zzeij = d_zze(i,j);
   const F_FLOAT rinv = 1.0/r;
 
-  F_FLOAT sum = c1*exp(-d1aij*r);
-  sum += c2*exp(-d2aij*r);
-  sum += c3*exp(-d3aij*r);
-  sum += c4*exp(-d4aij*r);
+  F_FLOAT sum = c1*Kokkos::Experimental::exp(-d1aij*r);
+  sum += c2*Kokkos::Experimental::exp(-d2aij*r);
+  sum += c3*Kokkos::Experimental::exp(-d3aij*r);
+  sum += c4*Kokkos::Experimental::exp(-d4aij*r);
 
   F_FLOAT result = zzeij*sum*rinv;
 
@@ -348,10 +348,10 @@ F_FLOAT PairZBLKokkos<DeviceType>::dzbldr(F_FLOAT r, int i, int j) const {
   const F_FLOAT zzeij = d_zze(i,j);
   const F_FLOAT rinv = 1.0/r;
 
-  const F_FLOAT e1 = exp(-d1aij*r);
-  const F_FLOAT e2 = exp(-d2aij*r);
-  const F_FLOAT e3 = exp(-d3aij*r);
-  const F_FLOAT e4 = exp(-d4aij*r);
+  const F_FLOAT e1 = Kokkos::Experimental::exp(-d1aij*r);
+  const F_FLOAT e2 = Kokkos::Experimental::exp(-d2aij*r);
+  const F_FLOAT e3 = Kokkos::Experimental::exp(-d3aij*r);
+  const F_FLOAT e4 = Kokkos::Experimental::exp(-d4aij*r);
 
   F_FLOAT sum = c1*e1;
   sum += c2*e2;
@@ -383,10 +383,10 @@ F_FLOAT PairZBLKokkos<DeviceType>::d2zbldr2(F_FLOAT r, int i, int j) const {
   const F_FLOAT zzeij = d_zze(i,j);
   const F_FLOAT rinv = 1.0/r;
 
-  const F_FLOAT e1 = exp(-d1aij*r);
-  const F_FLOAT e2 = exp(-d2aij*r);
-  const F_FLOAT e3 = exp(-d3aij*r);
-  const F_FLOAT e4 = exp(-d4aij*r);
+  const F_FLOAT e1 = Kokkos::Experimental::exp(-d1aij*r);
+  const F_FLOAT e2 = Kokkos::Experimental::exp(-d2aij*r);
+  const F_FLOAT e3 = Kokkos::Experimental::exp(-d3aij*r);
+  const F_FLOAT e4 = Kokkos::Experimental::exp(-d4aij*r);
 
   F_FLOAT sum = c1*e1;
   sum += c2*e2;

--- a/src/KOKKOS/pppm_kokkos.cpp
+++ b/src/KOKKOS/pppm_kokkos.cpp
@@ -141,7 +141,7 @@ template<class DeviceType>
 void PPPMKokkos<DeviceType>::settings(int narg, char **arg)
 {
   if (narg < 1) error->all(FLERR,"Illegal kspace_style pppm/kk command");
-  accuracy_relative = fabs(utils::numeric(FLERR,arg[0],false,lmp));
+  accuracy_relative = Kokkos::Experimental::fabs(utils::numeric(FLERR,arg[0],false,lmp));
 }
 
 /* ----------------------------------------------------------------------
@@ -936,9 +936,9 @@ void PPPMKokkos<DeviceType>::set_grid_global()
       error->all(FLERR,"KSpace accuracy must be > 0");
     if (q2 == 0.0)
       error->all(FLERR,"Must use 'kspace_modify gewald' for uncharged system");
-    g_ewald = accuracy*sqrt(natoms*cutoff*xprd*yprd*zprd) / (2.0*q2);
+    g_ewald = accuracy*Kokkos::Experimental::sqrt(natoms*cutoff*xprd*yprd*zprd) / (2.0*q2);
     if (g_ewald >= 1.0) g_ewald = (1.35 - 0.15*log(accuracy))/cutoff;
-    else g_ewald = sqrt(-log(g_ewald)) / cutoff;
+    else g_ewald = Kokkos::Experimental::sqrt(-log(g_ewald)) / cutoff;
   }
 
   // set optimal nx_pppm,ny_pppm,nz_pppm based on order and accuracy
@@ -1053,7 +1053,7 @@ double PPPMKokkos<DeviceType>::compute_df_kspace()
   double lprx = estimate_ik_error(h_x,xprd,natoms);
   double lpry = estimate_ik_error(h_y,yprd,natoms);
   double lprz = estimate_ik_error(h_z,zprd_slab,natoms);
-  df_kspace = sqrt(lprx*lprx + lpry*lpry + lprz*lprz) / sqrt(3.0);
+  df_kspace = Kokkos::Experimental::sqrt(lprx*lprx + lpry*lpry + lprz*lprz) / Kokkos::Experimental::sqrt(3.0);
   return df_kspace;
 }
 
@@ -1066,9 +1066,9 @@ double PPPMKokkos<DeviceType>::estimate_ik_error(double h, double prd, bigint na
 {
   double sum = 0.0;
   for (int m = 0; m < order; m++)
-    sum += acons(order,m) * pow(h*g_ewald,2.0*m);
-  double value = q2 * pow(h*g_ewald,(double)order) *
-    sqrt(g_ewald*prd*sqrt(MY_2PI)*sum/natoms) / (prd*prd);
+    sum += acons(order,m) * Kokkos::Experimental::pow(h*g_ewald,2.0*m);
+  double value = q2 * Kokkos::Experimental::pow(h*g_ewald,(double)order) *
+    Kokkos::Experimental::sqrt(g_ewald*prd*Kokkos::Experimental::sqrt(MY_2PI)*sum/natoms) / (prd*prd);
 
   return value;
 }
@@ -1086,7 +1086,7 @@ void PPPMKokkos<DeviceType>::adjust_gewald()
   for (int i = 0; i < LARGE; i++) {
     dx = newton_raphson_f() / derivf();
     g_ewald -= dx;
-    if (fabs(newton_raphson_f()) < SMALL) return;
+    if (Kokkos::Experimental::fabs(newton_raphson_f()) < SMALL) return;
   }
 
   char str[128];
@@ -1106,8 +1106,8 @@ double PPPMKokkos<DeviceType>::newton_raphson_f()
   double zprd = domain->zprd;
   bigint natoms = atomKK->natoms;
 
-  double df_rspace = 2.0*q2*exp(-g_ewald*g_ewald*cutoff*cutoff) /
-       sqrt(natoms*cutoff*xprd*yprd*zprd);
+  double df_rspace = 2.0*q2*Kokkos::Experimental::exp(-g_ewald*g_ewald*cutoff*cutoff) /
+       Kokkos::Experimental::sqrt(natoms*cutoff*xprd*yprd*zprd);
 
   double df_kspace = compute_df_kspace();
 
@@ -1149,10 +1149,10 @@ double PPPMKokkos<DeviceType>::final_accuracy()
   if (natoms == 0) natoms = 1; // avoid division by zero
 
   double df_kspace = compute_df_kspace();
-  double q2_over_sqrt = q2 / sqrt(natoms*cutoff*xprd*yprd*zprd);
-  double df_rspace = 2.0 * q2_over_sqrt * exp(-g_ewald*g_ewald*cutoff*cutoff);
+  double q2_over_sqrt = q2 / Kokkos::Experimental::sqrt(natoms*cutoff*xprd*yprd*zprd);
+  double df_rspace = 2.0 * q2_over_sqrt * Kokkos::Experimental::exp(-g_ewald*g_ewald*cutoff*cutoff);
   double df_table = estimate_table_accuracy(q2_over_sqrt,df_rspace);
-  double estimated_accuracy = sqrt(df_kspace*df_kspace + df_rspace*df_rspace +
+  double estimated_accuracy = Kokkos::Experimental::sqrt(df_kspace*df_kspace + df_rspace*df_rspace +
                                    df_table*df_table);
 
   return estimated_accuracy;
@@ -1220,11 +1220,11 @@ void PPPMKokkos<DeviceType>::compute_gf_ik()
   unitkz = (MY_2PI/zprd_slab);
 
   nbx = static_cast<int> ((g_ewald*xprd/(MY_PI*nx_pppm)) *
-                          pow(-log(EPS_HOC),0.25));
+                          Kokkos::Experimental::pow(-log(EPS_HOC),0.25));
   nby = static_cast<int> ((g_ewald*yprd/(MY_PI*ny_pppm)) *
-                          pow(-log(EPS_HOC),0.25));
+                          Kokkos::Experimental::pow(-log(EPS_HOC),0.25));
   nbz = static_cast<int> ((g_ewald*zprd_slab/(MY_PI*nz_pppm)) *
-                          pow(-log(EPS_HOC),0.25));
+                          Kokkos::Experimental::pow(-log(EPS_HOC),0.25));
   twoorder = 2*order;
 
   // merge three outer loops into one for better threading
@@ -1251,13 +1251,13 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik, const int &n) con
   k += nxlo_fft;
 
   const int mper = m - nz_pppm*(2*m/nz_pppm);
-  const double snz = square(sin(0.5*unitkz*mper*zprd_slab/nz_pppm));
+  const double snz = square(Kokkos::Experimental::sin(0.5*unitkz*mper*zprd_slab/nz_pppm));
 
   const int lper = l - ny_pppm*(2*l/ny_pppm);
-  const double sny = square(sin(0.5*unitky*lper*yprd/ny_pppm));
+  const double sny = square(Kokkos::Experimental::sin(0.5*unitky*lper*yprd/ny_pppm));
 
   const int kper = k - nx_pppm*(2*k/nx_pppm);
-  const double snx = square(sin(0.5*unitkx*kper*xprd/nx_pppm));
+  const double snx = square(Kokkos::Experimental::sin(0.5*unitkx*kper*xprd/nx_pppm));
 
   const double sqk = square(unitkx*kper) + square(unitky*lper) + square(unitkz*mper);
 
@@ -1268,19 +1268,19 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik, const int &n) con
 
     for (int nx = -nbx; nx <= nbx; nx++) {
       const double qx = unitkx*(kper+nx_pppm*nx);
-      const double sx = exp(-0.25*square(qx/g_ewald));
+      const double sx = Kokkos::Experimental::exp(-0.25*square(qx/g_ewald));
       const double argx = 0.5*qx*xprd/nx_pppm;
       const double wx = powsinxx(argx,twoorder);
 
       for (int ny = -nby; ny <= nby; ny++) {
         const double qy = unitky*(lper+ny_pppm*ny);
-        const double sy = exp(-0.25*square(qy/g_ewald));
+        const double sy = Kokkos::Experimental::exp(-0.25*square(qy/g_ewald));
         const double argy = 0.5*qy*yprd/ny_pppm;
         const double wy = powsinxx(argy,twoorder);
 
         for (int nz = -nbz; nz <= nbz; nz++) {
           const double qz = unitkz*(mper+nz_pppm*nz);
-          const double sz = exp(-0.25*square(qz/g_ewald));
+          const double sz = Kokkos::Experimental::exp(-0.25*square(qz/g_ewald));
           const double argz = 0.5*qz*zprd_slab/nz_pppm;
           const double wz = powsinxx(argz,twoorder);
 
@@ -1303,9 +1303,9 @@ template<class DeviceType>
 void PPPMKokkos<DeviceType>::compute_gf_ik_triclinic()
 {
   double tmp[3];
-  tmp[0] = (g_ewald/(MY_PI*nx_pppm)) * pow(-log(EPS_HOC),0.25);
-  tmp[1] = (g_ewald/(MY_PI*ny_pppm)) * pow(-log(EPS_HOC),0.25);
-  tmp[2] = (g_ewald/(MY_PI*nz_pppm)) * pow(-log(EPS_HOC),0.25);
+  tmp[0] = (g_ewald/(MY_PI*nx_pppm)) * Kokkos::Experimental::pow(-log(EPS_HOC),0.25);
+  tmp[1] = (g_ewald/(MY_PI*ny_pppm)) * Kokkos::Experimental::pow(-log(EPS_HOC),0.25);
+  tmp[2] = (g_ewald/(MY_PI*nz_pppm)) * Kokkos::Experimental::pow(-log(EPS_HOC),0.25);
   lamda2xT(&tmp[0],&tmp[0]);
   nbx = static_cast<int> (tmp[0]);
   nby = static_cast<int> (tmp[1]);
@@ -1325,15 +1325,15 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik_triclinic, const i
   //int n = (m - nzlo_fft)*(nyhi_fft+1 - nylo_fft)*(nxhi_fft+1 - nxlo_fft);
   //
   //const int mper = m - nz_pppm*(2*m/nz_pppm);
-  //const double snz = square(sin(MY_PI*mper/nz_pppm));
+  //const double snz = square(Kokkos::Experimental::sin(MY_PI*mper/nz_pppm));
   //
   //for (int l = nylo_fft; l <= nyhi_fft; l++) {
   //  const int lper = l - ny_pppm*(2*l/ny_pppm);
-  //  const double sny = square(sin(MY_PI*lper/ny_pppm));
+  //  const double sny = square(Kokkos::Experimental::sin(MY_PI*lper/ny_pppm));
   //
   //  for (int k = nxlo_fft; k <= nxhi_fft; k++) {
   //    const int kper = k - nx_pppm*(2*k/nx_pppm);
-  //    const double snx = square(sin(MY_PI*kper/nx_pppm));
+  //    const double snx = square(Kokkos::Experimental::sin(MY_PI*kper/nx_pppm));
   //
   //    double unitk_lamda[3];
   //    unitk_lamda[0] = 2.0*MY_PI*kper;
@@ -1367,13 +1367,13 @@ void PPPMKokkos<DeviceType>::operator()(TagPPPM_compute_gf_ik_triclinic, const i
   //            x2lamdaT(&b[0],&b[0]);
   //
   //            const double qx = unitk_lamda[0]+b[0];
-  //            const double sx = exp(-0.25*square(qx/g_ewald));
+  //            const double sx = Kokkos::Experimental::exp(-0.25*square(qx/g_ewald));
   //
   //            const double qy = unitk_lamda[1]+b[1];
-  //            const double sy = exp(-0.25*square(qy/g_ewald));
+  //            const double sy = Kokkos::Experimental::exp(-0.25*square(qy/g_ewald));
   //
   //            const double qz = unitk_lamda[2]+b[2];
-  //            const double sz = exp(-0.25*square(qz/g_ewald));
+  //            const double sz = Kokkos::Experimental::exp(-0.25*square(qz/g_ewald));
   //
   //            const double dot1 = unitk_lamda[0]*qx + unitk_lamda[1]*qy + unitk_lamda[2]*qz;
   //            const double dot2 = qx*qx+qy*qy+qz*qz;
@@ -2654,7 +2654,7 @@ void PPPMKokkos<DeviceType>::compute_rho1d(const int i, const FFT_SCALAR &dx, co
       k is odd integers if n is even and even integers if n is odd
               ---
              | n-1
-             | Sum a(l,j)*(x-k/2)**l   if abs(x-k/2) < 1/2
+             | Sum a(l,j)*(x-k/2)**l   if Kokkos::Experimental::abs(x-k/2) < 1/2
   wn(k,x) = <  l=0
              |
              |  0                       otherwise
@@ -2687,8 +2687,8 @@ void PPPMKokkos<DeviceType>::compute_rho_coeff()
         s += powf(0.5,(float) l+1) *
           (a[l][k-1+order] + powf(-1.0,(float) l) * a[l][k+1+order]) / (l+1);
 #else
-        s += pow(0.5,(double) l+1) *
-          (a[l][k-1+order] + pow(-1.0,(double) l) * a[l][k+1+order]) / (l+1);
+        s += Kokkos::Experimental::pow(0.5,(double) l+1) *
+          (a[l][k-1+order] + Kokkos::Experimental::pow(-1.0,(double) l) * a[l][k+1+order]) / (l+1);
 #endif
       }
       a[0][k+order] = s;
@@ -2733,7 +2733,7 @@ void PPPMKokkos<DeviceType>::slabcorr()
   //  per-atom energy translationally invariant
 
   dipole_r2 = 0.0;
-  if (eflag_atom || fabs(qsum) > SMALL) {
+  if (eflag_atom || Kokkos::Experimental::fabs(qsum) > SMALL) {
     copymode = 1;
     Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagPPPM_slabcorr2>(0,nlocal),*this,dipole_r2);
     copymode = 0;

--- a/src/KOKKOS/pppm_kokkos.h
+++ b/src/KOKKOS/pppm_kokkos.h
@@ -423,13 +423,13 @@ class PPPMKokkos : public PPPM, public KokkosBaseFFT {
 
 /* ----------------------------------------------------------------------
    denominator for Hockney-Eastwood Green's function
-     of x,y,z = sin(kx*deltax/2), etc
+     of x,y,z = Kokkos::Experimental::sin(kx*deltax/2), etc
 
             inf                 n-1
    S(n,k) = Sum  W(k+pi*j)**2 = Sum b(l)*(z*z)**l
            j=-inf               l=0
 
-          = -(z*z)**n /(2n-1)! * (d/dx)**(2n-1) cot(x)  at z = sin(x)
+          = -(z*z)**n /(2n-1)! * (d/dx)**(2n-1) cot(x)  at z = Kokkos::Experimental::sin(x)
    gf_b = denominator expansion coeffs
 ------------------------------------------------------------------------- */
 

--- a/src/KOKKOS/region_block_kokkos.cpp
+++ b/src/KOKKOS/region_block_kokkos.cpp
@@ -130,7 +130,7 @@ void RegBlockKokkos<DeviceType>::inverse_transform(double &x, double &y, double 
    A = D - C = vector from R line to X0, i.e. Dperp
    B = R0 cross A = vector perp to A in plane of rotation, same len as A
    A,B define plane of circular rotation around R line
-   new x,y,z = P + C + A cos(angle) + B sin(angle)
+   new x,y,z = P + C + A Kokkos::Experimental::cos(angle) + B Kokkos::Experimental::sin(angle)
 ------------------------------------------------------------------------- */
 
 template<class DeviceType>
@@ -139,8 +139,8 @@ void RegBlockKokkos<DeviceType>::rotate(double &x, double &y, double &z, double 
 {
   double a[3],b[3],c[3],d[3],disp[3];
 
-  double sine = sin(angle);
-  double cosine = cos(angle);
+  double sine = Kokkos::Experimental::sin(angle);
+  double cosine = Kokkos::Experimental::cos(angle);
   d[0] = x - point[0];
   d[1] = y - point[1];
   d[2] = z - point[2];

--- a/src/KOKKOS/sna_kokkos.h
+++ b/src/KOKKOS/sna_kokkos.h
@@ -171,15 +171,15 @@ inline
   static KOKKOS_FORCEINLINE_FUNCTION
   void sincos_wrapper(double x, double* sin_, double *cos_) {
 #ifdef __SYCL_DEVICE_ONLY__
-    *sin_ = sycl::sincos(x, cos_);
+    *sin_ = sycl::sinKokkos::Experimental::cos(x, cos_);
 #else
-    sincos(x, sin_, cos_);
+    sinKokkos::Experimental::cos(x, sin_, cos_);
 #endif
   }
   static KOKKOS_FORCEINLINE_FUNCTION
   void sincos_wrapper(float x, float* sin_, float *cos_) {
 #ifdef __SYCL_DEVICE_ONLY__
-    *sin_ = sycl::sincos(x, cos_);
+    *sin_ = sycl::sinKokkos::Experimental::cos(x, cos_);
 #else
     sincosf(x, sin_, cos_);
 #endif

--- a/src/KOKKOS/sna_kokkos_impl.h
+++ b/src/KOKKOS/sna_kokkos_impl.h
@@ -369,7 +369,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_cayley_klein(const
   const auto y = rij(iatom,jnbor,1);
   const auto z = rij(iatom,jnbor,2);
   const auto rsq = x * x + y * y + z * z;
-  const auto r = sqrt(rsq);
+  const auto r = Kokkos::Experimental::sqrt(rsq);
   const auto rcut = rcutij(iatom, jnbor);
   const auto rscale0 = rfac0 * static_cast<real_type>(MY_PI) / (rcut - rmin0);
   const auto theta0 = (r - rmin0) * rscale0;
@@ -389,7 +389,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_cayley_klein(const
   const auto uy = y * rinv;
   const auto uz = z * rinv;
 
-  const auto r0inv = static_cast<real_type>(1.0) / sqrt(r * r + z0 * z0);
+  const auto r0inv = static_cast<real_type>(1.0) / Kokkos::Experimental::sqrt(r * r + z0 * z0);
 
   const complex a = { z0 * r0inv, -z * r0inv };
   const complex b = { r0inv * y, -r0inv * x };
@@ -1168,7 +1168,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_ui_cpu(const typen
   y = rij(iatom,jnbor,1);
   z = rij(iatom,jnbor,2);
   rsq = x * x + y * y + z * z;
-  r = sqrt(rsq);
+  r = Kokkos::Experimental::sqrt(rsq);
 
   theta0 = (r - rmin0) * rfac0 * MY_PI / (rcutij(iatom,jnbor) - rmin0);
   //    theta0 = (r - rmin0) * rscale0;
@@ -1468,7 +1468,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_duidrj_cpu(const t
   y = rij(iatom,jnbor,1);
   z = rij(iatom,jnbor,2);
   rsq = x * x + y * y + z * z;
-  r = sqrt(rsq);
+  r = Kokkos::Experimental::sqrt(rsq);
   auto rscale0 = rfac0 * static_cast<real_type>(MY_PI) / (rcutij(iatom,jnbor) - rmin0);
   theta0 = (r - rmin0) * rscale0;
   sincos_wrapper(theta0, &sn, &cs);
@@ -1595,7 +1595,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_uarray_cpu(const t
 
   // compute Cayley-Klein parameters for unit quaternion
 
-  r0inv = static_cast<real_type>(1.0) / sqrt(r * r + z0 * z0);
+  r0inv = static_cast<real_type>(1.0) / Kokkos::Experimental::sqrt(r * r + z0 * z0);
   a_r = r0inv * z0;
   a_i = -r0inv * z;
   b_r = r0inv * y;
@@ -1693,7 +1693,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::compute_duarray_cpu(const 
   real_type uy = y * rinv;
   real_type uz = z * rinv;
 
-  r0inv = 1.0 / sqrt(r * r + z0 * z0);
+  r0inv = 1.0 / Kokkos::Experimental::sqrt(r * r + z0 * z0);
   a_r = z0 * r0inv;
   a_i = -z * r0inv;
   b_r = y * r0inv;
@@ -2039,7 +2039,7 @@ inline
 double SNAKokkos<DeviceType, real_type, vector_length>::deltacg(int j1, int j2, int j)
 {
   double sfaccg = factorial((j1 + j2 + j) / 2 + 1);
-  return sqrt(factorial((j1 + j2 - j) / 2) *
+  return Kokkos::Experimental::sqrt(factorial((j1 + j2 - j) / 2) *
               factorial((j1 - j2 + j) / 2) *
               factorial((-j1 + j2 + j) / 2) / sfaccg);
 }
@@ -2098,7 +2098,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::init_clebsch_gordan()
 
             cc2 = 2 * m - j;
             dcg = deltacg(j1, j2, j);
-            sfaccg = sqrt(factorial((j1 + aa2) / 2) *
+            sfaccg = Kokkos::Experimental::sqrt(factorial((j1 + aa2) / 2) *
                           factorial((j1 - aa2) / 2) *
                           factorial((j2 + bb2) / 2) *
                           factorial((j2 - bb2) / 2) *
@@ -2126,7 +2126,7 @@ void SNAKokkos<DeviceType, real_type, vector_length>::init_rootpqarray()
   auto h_rootpqarray = Kokkos::create_mirror_view(rootpqarray);
   for (int p = 1; p <= twojmax; p++)
     for (int q = 1; q <= twojmax; q++)
-      h_rootpqarray(p,q) = static_cast<real_type>(sqrt(static_cast<double>(p)/q));
+      h_rootpqarray(p,q) = static_cast<real_type>(Kokkos::Experimental::sqrt(static_cast<double>(p)/q));
   Kokkos::deep_copy(rootpqarray,h_rootpqarray);
 }
 
@@ -2169,7 +2169,7 @@ real_type SNAKokkos<DeviceType, real_type, vector_length>::compute_sfac(real_typ
     else if (r > rcut) return zero;
     else {
       auto rcutfac = static_cast<real_type>(MY_PI) / (rcut - rmin0);
-      return onehalf * (cos((r - rmin0) * rcutfac) + one);
+      return onehalf * (Kokkos::Experimental::cos((r - rmin0) * rcutfac) + one);
     }
   }
   return zero;
@@ -2189,7 +2189,7 @@ real_type SNAKokkos<DeviceType, real_type, vector_length>::compute_dsfac(real_ty
     else if (r > rcut) return zero;
     else {
       auto rcutfac = static_cast<real_type>(MY_PI) / (rcut - rmin0);
-      return -onehalf * sin((r - rmin0) * rcutfac) * rcutfac;
+      return -onehalf * Kokkos::Experimental::sin((r - rmin0) * rcutfac) * rcutfac;
     }
   }
   return zero;


### PR DESCRIPTION
**Summary**

This patch replaces all usages of math builtins in the KOKKOS package of
LAMMPS with those in the Kokkos::Experimental namespace.
This enables transparently using the backend-specific intrinsics for
each Kokkos backend.
Some builtins are missing in Kokkos, this is blocked until the equivalent Kokkos PR is up.

**Related Issue(s)**

N/A

**Author(s)**

Ruyman Reyes <ruyman AT codeplay.com>

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

This will only work with Kokkos version 3.4 onwards.

**Implementation Notes**

The builtins have been replaced via reg-exp, and tested by compiling and running the application.


**Post Submission Checklist**

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

N/A


